### PR TITLE
Apply SOLID principles refactoring across domain and web layers

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/ControllerErrorAdvice.java
+++ b/src/main/java/solutions/mystuff/application/web/ControllerErrorAdvice.java
@@ -2,6 +2,7 @@ package solutions.mystuff.application.web;
 
 import java.time.format.DateTimeParseException;
 import java.util.Collections;
+import java.util.Map;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -22,6 +23,23 @@ public class ControllerErrorAdvice {
     private static final Logger log =
             LoggerFactory.getLogger(
                     ControllerErrorAdvice.class);
+
+    private static final Map<String, ErrorViewConfig>
+            VIEW_REGISTRY = Map.of(
+                    "/schedules",
+                    new ErrorViewConfig("schedules",
+                            "schedules"),
+                    "/vendors",
+                    new ErrorViewConfig(
+                            "redirect:/vendors", null),
+                    "/settings",
+                    new ErrorViewConfig(
+                            "redirect:/settings", null),
+                    "/reports",
+                    new ErrorViewConfig("reports", null));
+
+    private static final ErrorViewConfig DEFAULT_VIEW =
+            new ErrorViewConfig("items", "items");
 
     /** Handles invalid date format input. */
     @ExceptionHandler(DateTimeParseException.class)
@@ -62,22 +80,26 @@ public class ControllerErrorAdvice {
     String resolveErrorView(
             Model model, HttpServletRequest request) {
         String path = request.getRequestURI();
-        if (path.startsWith("/schedules")) {
-            model.addAttribute("schedules",
+        for (Map.Entry<String, ErrorViewConfig> entry
+                : VIEW_REGISTRY.entrySet()) {
+            if (path.startsWith(entry.getKey())) {
+                return applyConfig(
+                        model, entry.getValue());
+            }
+        }
+        return applyConfig(model, DEFAULT_VIEW);
+    }
+
+    private String applyConfig(
+            Model model, ErrorViewConfig config) {
+        if (config.emptyListAttr != null) {
+            model.addAttribute(config.emptyListAttr,
                     Collections.emptyList());
-            return "schedules";
         }
-        if (path.startsWith("/vendors")) {
-            return "redirect:/vendors";
-        }
-        if (path.startsWith("/settings")) {
-            return "redirect:/settings";
-        }
-        if (path.startsWith("/reports")) {
-            return "reports";
-        }
-        model.addAttribute("items",
-                Collections.emptyList());
-        return "items";
+        return config.viewName;
+    }
+
+    private record ErrorViewConfig(
+            String viewName, String emptyListAttr) {
     }
 }

--- a/src/main/java/solutions/mystuff/application/web/InputValidator.java
+++ b/src/main/java/solutions/mystuff/application/web/InputValidator.java
@@ -3,19 +3,12 @@ package solutions.mystuff.application.web;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 
+import solutions.mystuff.domain.model.Validation;
+
 /**
  * Static validation utility for controller request parameters.
- *
- * <div class="mermaid">
- * classDiagram
- *     class InputValidator {
- *         +requireNotBlank(String, String)$ String
- *         +requireMaxLength(String, String, int)$ void
- *         +requirePositive(int, String)$ void
- *         +parseDate(String, String)$ LocalDate
- *         +validateScheduleFields(String, int)$ void
- *     }
- * </div>
+ * Delegates to {@link Validation} for generic checks and adds
+ * web-specific helpers like date parsing.
  *
  * @see ItemController
  * @see ScheduleController
@@ -28,33 +21,22 @@ public final class InputValidator {
     /** Validates that the value is not null or blank. */
     static String requireNotBlank(
             String value, String fieldName) {
-        if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException(
-                    fieldName + " is required");
-        }
-        return value.trim();
+        return Validation.requireNotBlank(
+                value, fieldName);
     }
 
     /** Validates that the value does not exceed the maximum length. */
     static void requireMaxLength(
             String value, String fieldName,
             int maxLength) {
-        if (value != null
-                && value.trim().length() > maxLength) {
-            throw new IllegalArgumentException(
-                    fieldName
-                            + " exceeds maximum length of "
-                            + maxLength);
-        }
+        Validation.requireMaxLength(
+                value, fieldName, maxLength);
     }
 
     /** Validates that the integer value is at least 1. */
     static void requirePositive(
             int value, String fieldName) {
-        if (value < 1) {
-            throw new IllegalArgumentException(
-                    fieldName + " must be at least 1");
-        }
+        Validation.requirePositive(value, fieldName);
     }
 
     /** Parses an ISO date string, throwing on invalid input. */

--- a/src/main/java/solutions/mystuff/application/web/ItemController.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemController.java
@@ -3,8 +3,6 @@ package solutions.mystuff.application.web;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.AppUser;
@@ -19,6 +17,7 @@ import solutions.mystuff.domain.port.in.ItemQuery;
 import solutions.mystuff.domain.port.in.ScheduleLifecycle;
 import solutions.mystuff.domain.port.in.RecordCreation;
 import solutions.mystuff.domain.port.in.VendorManagement;
+import solutions.mystuff.domain.port.in.VendorQuery;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,17 +31,6 @@ import org.springframework.web.bind.annotation
 /**
  * Handles item CRUD and service operations at /items endpoints.
  *
- * <div class="mermaid">
- * sequenceDiagram
- *     Browser->>ItemController: GET/POST /items/**
- *     ItemController->>ControllerHelper: resolveUser(principal)
- *     ItemController->>ItemManagement: createItem()
- *     ItemController->>ItemQuery: findByOrganization()
- *     ItemController->>ScheduleLifecycle: createSchedule/complete/skip
- *     ItemController->>RecordCreation: createRecord()
- *     ItemController-->>Browser: Thymeleaf view or redirect
- * </div>
- *
  * @see ControllerHelper
  * @see InputValidator
  */
@@ -51,11 +39,14 @@ public class ItemController {
 
     private static final Logger log =
             LoggerFactory.getLogger(ItemController.class);
+    private static final String NEW_VENDOR_SENTINEL =
+            "__new__";
 
     private final ControllerHelper helper;
     private final ItemManagement itemService;
     private final ItemQuery itemQuery;
     private final VendorManagement vendorService;
+    private final VendorQuery vendorQuery;
     private final ScheduleLifecycle scheduleService;
     private final RecordCreation recordService;
 
@@ -64,12 +55,14 @@ public class ItemController {
             ItemManagement itemService,
             ItemQuery itemQuery,
             VendorManagement vendorService,
+            VendorQuery vendorQuery,
             ScheduleLifecycle scheduleService,
             RecordCreation recordService) {
         this.helper = helper;
         this.itemService = itemService;
         this.itemQuery = itemQuery;
         this.vendorService = vendorService;
+        this.vendorQuery = vendorQuery;
         this.scheduleService = scheduleService;
         this.recordService = recordService;
     }
@@ -178,7 +171,7 @@ public class ItemController {
         try {
             UUID orgId = user.getOrganization().getId();
             Item item = findItem(itemId, orgId);
-            Vendor vendor = vendorService.resolveVendor(
+            Vendor vendor = resolveVendor(
                     orgId, vendorId, newVendorName,
                     newVendorPhone);
             LocalDate date = InputValidator.parseDate(
@@ -188,37 +181,13 @@ public class ItemController {
                         null, null, vendor, summary,
                         date, techName);
             } else {
-                completeNextSchedule(orgId, item,
-                        vendor, summary, date, techName);
+                scheduleService.completeNextForItem(
+                        orgId, itemId, vendor,
+                        summary, date, techName);
             }
             return "redirect:/items";
         } finally {
             helper.clearOrgMdc();
-        }
-    }
-
-    private void completeNextSchedule(
-            UUID orgId, Item item, Vendor vendor,
-            String summary, LocalDate date,
-            String techName) {
-        List<ServiceSchedule> schedules =
-                itemQuery.findSchedulesByItem(
-                        item.getId(), orgId);
-        ServiceSchedule next = schedules.stream()
-                .filter(ServiceSchedule::isActive)
-                .min(Comparator.comparing(
-                        s -> s.getNextDueDate() != null
-                                ? s.getNextDueDate()
-                                : LocalDate.MAX))
-                .orElse(null);
-        if (next != null) {
-            scheduleService.completeSchedule(
-                    next.getId(), orgId, vendor,
-                    summary, date, techName);
-        } else {
-            recordService.createRecord(orgId, item,
-                    null, null, vendor, summary,
-                    date, techName);
         }
     }
 
@@ -241,7 +210,7 @@ public class ItemController {
         helper.setOrgMdc(user);
         try {
             UUID orgId = user.getOrganization().getId();
-            Vendor vendor = vendorService.resolveVendor(
+            Vendor vendor = resolveVendor(
                     orgId, vendorId, newVendorName,
                     newVendorPhone);
             LocalDate due = InputValidator.parseDate(
@@ -274,7 +243,7 @@ public class ItemController {
         helper.setOrgMdc(user);
         try {
             UUID orgId = user.getOrganization().getId();
-            Vendor vendor = vendorService.resolveVendor(
+            Vendor vendor = resolveVendor(
                     orgId, vendorId, newVendorName,
                     newVendorPhone);
             LocalDate date = InputValidator.parseDate(
@@ -307,6 +276,28 @@ public class ItemController {
         } finally {
             helper.clearOrgMdc();
         }
+    }
+
+    private Vendor resolveVendor(
+            UUID orgId, String vendorId,
+            String newVendorName,
+            String newVendorPhone) {
+        if (NEW_VENDOR_SENTINEL.equals(vendorId)) {
+            return vendorService.createVendor(
+                    orgId, newVendorName,
+                    newVendorPhone);
+        }
+        if (vendorId != null && !vendorId.isBlank()) {
+            return vendorQuery.findAllVendors(orgId)
+                    .stream()
+                    .filter(v -> v.getId().toString()
+                            .equals(vendorId))
+                    .findFirst()
+                    .orElseThrow(() ->
+                            new IllegalArgumentException(
+                                    "Vendor not found"));
+        }
+        return null;
     }
 
     private String handleNoOrg(
@@ -352,8 +343,7 @@ public class ItemController {
         LinkHeaderBuilder.addLinkHeader(
                 response, "/items", result, q);
         model.addAttribute("vendors",
-                itemQuery.findVendorsByOrganization(
-                        orgId));
+                vendorQuery.findAllVendors(orgId));
         model.addAttribute("frequencyUnits",
                 FrequencyUnit.values());
     }

--- a/src/main/java/solutions/mystuff/application/web/ItemHistoryPdf.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemHistoryPdf.java
@@ -1,7 +1,6 @@
 package solutions.mystuff.application.web;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import solutions.mystuff.domain.model.Item;
@@ -9,8 +8,6 @@ import solutions.mystuff.domain.model.ServiceRecord;
 import solutions.mystuff.domain.model.ServiceSchedule;
 import com.lowagie.text.Document;
 import com.lowagie.text.Element;
-import com.lowagie.text.Font;
-import com.lowagie.text.FontFactory;
 import com.lowagie.text.PageSize;
 import com.lowagie.text.Paragraph;
 import com.lowagie.text.Phrase;
@@ -23,33 +20,10 @@ import jakarta.servlet.http.HttpServletResponse;
  * Generates a PDF report of an item's service history
  * and active schedules using OpenPDF.
  *
- * <div class="mermaid">
- * sequenceDiagram
- *     ReportController->>ItemHistoryPdf: write(response, item, ...)
- *     ItemHistoryPdf->>Document: org header, item info, tables
- *     ItemHistoryPdf-->>Browser: PDF via HttpServletResponse
- * </div>
- *
  * @see ReportController
+ * @see PdfHelper
  */
 final class ItemHistoryPdf {
-
-    private static final DateTimeFormatter FMT =
-            DateTimeFormatter.ofPattern("MMM d, yyyy");
-    private static final Font TITLE_FONT =
-            FontFactory.getFont(
-                    FontFactory.HELVETICA_BOLD, 16);
-    private static final Font SECTION_FONT =
-            FontFactory.getFont(
-                    FontFactory.HELVETICA_BOLD, 13);
-    private static final Font LABEL_FONT =
-            FontFactory.getFont(
-                    FontFactory.HELVETICA_BOLD, 10);
-    private static final Font BODY_FONT =
-            FontFactory.getFont(
-                    FontFactory.HELVETICA, 10);
-    private static final java.awt.Color HEADER_BG =
-            new java.awt.Color(220, 220, 220);
 
     private ItemHistoryPdf() {
     }
@@ -70,7 +44,7 @@ final class ItemHistoryPdf {
         PdfWriter.getInstance(doc,
                 response.getOutputStream());
         doc.open();
-        addOrgHeader(doc, orgName, username);
+        PdfHelper.addOrgHeader(doc, orgName, username);
         addTitle(doc, orgName, item);
         addItemDetails(doc, item);
         addScheduleSection(doc, schedules);
@@ -78,33 +52,20 @@ final class ItemHistoryPdf {
         doc.close();
     }
 
-    private static void addOrgHeader(
-            Document doc, String orgName,
-            String username) throws Exception {
-        Paragraph org = new Paragraph(
-                orgName, LABEL_FONT);
-        org.setAlignment(Element.ALIGN_LEFT);
-        doc.add(org);
-        Paragraph user = new Paragraph(
-                username, BODY_FONT);
-        user.setAlignment(Element.ALIGN_LEFT);
-        user.setSpacingAfter(8);
-        doc.add(user);
-    }
-
     private static void addTitle(
             Document doc, String orgName, Item item)
             throws Exception {
         Paragraph title = new Paragraph(
                 orgName + " — " + item.getName(),
-                TITLE_FONT);
+                PdfHelper.TITLE_FONT);
         title.setAlignment(Element.ALIGN_CENTER);
         title.setSpacingAfter(4);
         doc.add(title);
         Paragraph gen = new Paragraph(
                 "Generated "
-                        + LocalDate.now().format(FMT),
-                BODY_FONT);
+                        + LocalDate.now().format(
+                                PdfHelper.FMT),
+                PdfHelper.BODY_FONT);
         gen.setAlignment(Element.ALIGN_RIGHT);
         gen.setSpacingAfter(12);
         doc.add(gen);
@@ -117,13 +78,13 @@ final class ItemHistoryPdf {
         table.setWidthPercentage(100);
         table.setSpacingAfter(12);
         addLabelValue(table, "Location",
-                safe(item.getLocation()));
+                PdfHelper.safe(item.getLocation()));
         addLabelValue(table, "Manufacturer",
-                safe(item.getManufacturer()));
+                PdfHelper.safe(item.getManufacturer()));
         addLabelValue(table, "Model",
-                safe(item.getModelName()));
+                PdfHelper.safe(item.getModelName()));
         addLabelValue(table, "Serial #",
-                safe(item.getSerialNumber()));
+                PdfHelper.safe(item.getSerialNumber()));
         doc.add(table);
     }
 
@@ -131,12 +92,12 @@ final class ItemHistoryPdf {
             PdfPTable table,
             String label, String value) {
         PdfPCell lbl = new PdfPCell(
-                new Phrase(label, LABEL_FONT));
+                new Phrase(label, PdfHelper.LABEL_FONT));
         lbl.setBorder(0);
         lbl.setPadding(3);
         table.addCell(lbl);
         PdfPCell val = new PdfPCell(
-                new Phrase(value, BODY_FONT));
+                new Phrase(value, PdfHelper.BODY_FONT));
         val.setBorder(0);
         val.setPadding(3);
         table.addCell(val);
@@ -147,7 +108,8 @@ final class ItemHistoryPdf {
             List<ServiceSchedule> schedules)
             throws Exception {
         Paragraph heading = new Paragraph(
-                "Active Schedules", SECTION_FONT);
+                "Active Schedules",
+                PdfHelper.SECTION_FONT);
         heading.setSpacingAfter(6);
         doc.add(heading);
         List<ServiceSchedule> active = schedules
@@ -155,7 +117,8 @@ final class ItemHistoryPdf {
                 .toList();
         if (active.isEmpty()) {
             doc.add(new Paragraph(
-                    "No active schedules.", BODY_FONT));
+                    "No active schedules.",
+                    PdfHelper.BODY_FONT));
         } else {
             doc.add(buildScheduleTable(active));
         }
@@ -168,22 +131,24 @@ final class ItemHistoryPdf {
                 new float[]{3, 2, 2, 2, 2});
         table.setWidthPercentage(100);
         table.setSpacingAfter(16);
-        addHeaderRow(table, "Service Type", "Vendor",
-                "Next Due", "Frequency",
+        PdfHelper.addHeaderRow(table, "Service Type",
+                "Vendor", "Next Due", "Frequency",
                 "Last Completed");
         for (ServiceSchedule s : schedules) {
-            addCell(table, s.getServiceType());
-            addCell(table,
+            PdfHelper.addCell(table, s.getServiceType());
+            PdfHelper.addCell(table,
                     s.getPreferredVendor() != null
                             ? s.getPreferredVendor()
                                     .getName() : "");
-            addCell(table,
-                    fmtDate(s.getNextDueDate()));
-            addCell(table,
+            PdfHelper.addCell(table,
+                    PdfHelper.fmtDate(
+                            s.getNextDueDate()));
+            PdfHelper.addCell(table,
                     "Every " + s.getFrequencyInterval()
                             + " " + s.getFrequencyUnit());
-            addCell(table,
-                    fmtDate(s.getLastCompletedDate()));
+            PdfHelper.addCell(table,
+                    PdfHelper.fmtDate(
+                            s.getLastCompletedDate()));
         }
         return table;
     }
@@ -193,12 +158,14 @@ final class ItemHistoryPdf {
             List<ServiceRecord> records)
             throws Exception {
         Paragraph heading = new Paragraph(
-                "Service History", SECTION_FONT);
+                "Service History",
+                PdfHelper.SECTION_FONT);
         heading.setSpacingAfter(6);
         doc.add(heading);
         if (records.isEmpty()) {
             doc.add(new Paragraph(
-                    "No service records.", BODY_FONT));
+                    "No service records.",
+                    PdfHelper.BODY_FONT));
         } else {
             doc.add(buildRecordTable(records));
         }
@@ -210,55 +177,25 @@ final class ItemHistoryPdf {
         PdfPTable table = new PdfPTable(
                 new float[]{2, 2, 2, 2, 4});
         table.setWidthPercentage(100);
-        addHeaderRow(table, "Date", "Service Type",
-                "Vendor", "Tech", "Summary");
+        PdfHelper.addHeaderRow(table, "Date",
+                "Service Type", "Vendor", "Tech",
+                "Summary");
         for (ServiceRecord r : records) {
-            addCell(table,
-                    fmtDate(r.getServiceDate()));
-            addCell(table, safe(r.getServiceType()));
-            addCell(table,
+            PdfHelper.addCell(table,
+                    PdfHelper.fmtDate(
+                            r.getServiceDate()));
+            PdfHelper.addCell(table,
+                    PdfHelper.safe(r.getServiceType()));
+            PdfHelper.addCell(table,
                     r.getVendor() != null
                             ? r.getVendor().getName()
                             : "");
-            addCell(table,
-                    extractTech(r.getDescription()));
-            addCell(table, safe(r.getSummary()));
+            PdfHelper.addCell(table,
+                    PdfHelper.safe(
+                            r.getTechnicianName()));
+            PdfHelper.addCell(table,
+                    PdfHelper.safe(r.getSummary()));
         }
         return table;
-    }
-
-    private static void addHeaderRow(
-            PdfPTable table, String... headers) {
-        for (String h : headers) {
-            PdfPCell cell = new PdfPCell(
-                    new Phrase(h, LABEL_FONT));
-            cell.setBackgroundColor(HEADER_BG);
-            cell.setPadding(5);
-            table.addCell(cell);
-        }
-    }
-
-    private static void addCell(
-            PdfPTable table, String text) {
-        PdfPCell cell = new PdfPCell(
-                new Phrase(text, BODY_FONT));
-        cell.setPadding(4);
-        table.addCell(cell);
-    }
-
-    private static String fmtDate(LocalDate date) {
-        return date != null ? date.format(FMT) : "";
-    }
-
-    private static String safe(String val) {
-        return val != null ? val : "";
-    }
-
-    private static String extractTech(String desc) {
-        if (desc != null
-                && desc.startsWith("Technician: ")) {
-            return desc.substring(12);
-        }
-        return "";
     }
 }

--- a/src/main/java/solutions/mystuff/application/web/PdfHelper.java
+++ b/src/main/java/solutions/mystuff/application/web/PdfHelper.java
@@ -1,0 +1,81 @@
+package solutions.mystuff.application.web;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+
+/**
+ * Shared PDF helper methods for table building, formatting,
+ * and org headers, used by all PDF report generators.
+ */
+final class PdfHelper {
+
+    static final DateTimeFormatter FMT =
+            DateTimeFormatter.ofPattern("MMM d, yyyy");
+    static final Font TITLE_FONT =
+            FontFactory.getFont(
+                    FontFactory.HELVETICA_BOLD, 16);
+    static final Font SECTION_FONT =
+            FontFactory.getFont(
+                    FontFactory.HELVETICA_BOLD, 13);
+    static final Font LABEL_FONT =
+            FontFactory.getFont(
+                    FontFactory.HELVETICA_BOLD, 10);
+    static final Font BODY_FONT =
+            FontFactory.getFont(
+                    FontFactory.HELVETICA, 10);
+    static final java.awt.Color HEADER_BG =
+            new java.awt.Color(220, 220, 220);
+
+    private PdfHelper() {
+    }
+
+    static void addOrgHeader(
+            Document doc, String orgName,
+            String username) throws Exception {
+        Paragraph org = new Paragraph(
+                orgName, LABEL_FONT);
+        org.setAlignment(Element.ALIGN_LEFT);
+        doc.add(org);
+        Paragraph user = new Paragraph(
+                username, BODY_FONT);
+        user.setAlignment(Element.ALIGN_LEFT);
+        user.setSpacingAfter(8);
+        doc.add(user);
+    }
+
+    static void addHeaderRow(
+            PdfPTable table, String... headers) {
+        for (String h : headers) {
+            PdfPCell cell = new PdfPCell(
+                    new Phrase(h, LABEL_FONT));
+            cell.setBackgroundColor(HEADER_BG);
+            cell.setPadding(5);
+            table.addCell(cell);
+        }
+    }
+
+    static void addCell(
+            PdfPTable table, String text) {
+        PdfPCell cell = new PdfPCell(
+                new Phrase(text, BODY_FONT));
+        cell.setPadding(4);
+        table.addCell(cell);
+    }
+
+    static String fmtDate(LocalDate date) {
+        return date != null ? date.format(FMT) : "";
+    }
+
+    static String safe(String val) {
+        return val != null ? val : "";
+    }
+}

--- a/src/main/java/solutions/mystuff/application/web/ScheduleController.java
+++ b/src/main/java/solutions/mystuff/application/web/ScheduleController.java
@@ -10,10 +10,10 @@ import solutions.mystuff.domain.model.FrequencyUnit;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.ServiceSchedule;
 import solutions.mystuff.domain.model.Vendor;
-import solutions.mystuff.domain.port.in.ItemQuery;
 import solutions.mystuff.domain.port.in.ScheduleLifecycle;
 import solutions.mystuff.domain.port.in.ScheduleQuery;
 import solutions.mystuff.domain.port.in.VendorManagement;
+import solutions.mystuff.domain.port.in.VendorQuery;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,16 +27,6 @@ import org.springframework.web.bind.annotation
 /**
  * Manages service schedule CRUD at /schedules endpoints.
  *
- * <div class="mermaid">
- * sequenceDiagram
- *     Browser->>ScheduleController: GET/POST /schedules/**
- *     ScheduleController->>ControllerHelper: resolveUser(principal)
- *     ScheduleController->>ScheduleQuery: findActiveByOrganization()
- *     ScheduleController->>VendorManagement: resolveVendor()
- *     ScheduleController->>ScheduleLifecycle: create/edit/complete/deactivate
- *     ScheduleController-->>Browser: Thymeleaf view or redirect
- * </div>
- *
  * @see ControllerHelper
  * @see InputValidator
  */
@@ -46,23 +36,25 @@ public class ScheduleController {
     private static final Logger log =
             LoggerFactory.getLogger(
                     ScheduleController.class);
+    private static final String NEW_VENDOR_SENTINEL =
+            "__new__";
 
     private final ControllerHelper helper;
-    private final ItemQuery itemQuery;
     private final ScheduleQuery scheduleQuery;
     private final VendorManagement vendorService;
+    private final VendorQuery vendorQuery;
     private final ScheduleLifecycle scheduleService;
 
     public ScheduleController(
             ControllerHelper helper,
-            ItemQuery itemQuery,
             ScheduleQuery scheduleQuery,
             VendorManagement vendorService,
+            VendorQuery vendorQuery,
             ScheduleLifecycle scheduleService) {
         this.helper = helper;
-        this.itemQuery = itemQuery;
         this.scheduleQuery = scheduleQuery;
         this.vendorService = vendorService;
+        this.vendorQuery = vendorQuery;
         this.scheduleService = scheduleService;
     }
 
@@ -108,7 +100,7 @@ public class ScheduleController {
         helper.setOrgMdc(user);
         try {
             UUID orgId = user.getOrganization().getId();
-            Vendor vendor = vendorService.resolveVendor(
+            Vendor vendor = resolveVendor(
                     orgId, vendorId, newVendorName,
                     newVendorPhone);
             LocalDate date = InputValidator.parseDate(
@@ -158,7 +150,7 @@ public class ScheduleController {
         helper.setOrgMdc(user);
         try {
             UUID orgId = user.getOrganization().getId();
-            Vendor vendor = vendorService.resolveVendor(
+            Vendor vendor = resolveVendor(
                     orgId, vendorId, newVendorName,
                     newVendorPhone);
             LocalDate due = InputValidator.parseDate(
@@ -170,6 +162,28 @@ public class ScheduleController {
         } finally {
             helper.clearOrgMdc();
         }
+    }
+
+    private Vendor resolveVendor(
+            UUID orgId, String vendorId,
+            String newVendorName,
+            String newVendorPhone) {
+        if (NEW_VENDOR_SENTINEL.equals(vendorId)) {
+            return vendorService.createVendor(
+                    orgId, newVendorName,
+                    newVendorPhone);
+        }
+        if (vendorId != null && !vendorId.isBlank()) {
+            return vendorQuery.findAllVendors(orgId)
+                    .stream()
+                    .filter(v -> v.getId().toString()
+                            .equals(vendorId))
+                    .findFirst()
+                    .orElseThrow(() ->
+                            new IllegalArgumentException(
+                                    "Vendor not found"));
+        }
+        return null;
     }
 
     private String handleNoOrg(
@@ -196,8 +210,7 @@ public class ScheduleController {
         LinkHeaderBuilder.addLinkHeader(
                 response, "/schedules", result, null);
         model.addAttribute("vendors",
-                itemQuery.findVendorsByOrganization(
-                        orgId));
+                vendorQuery.findAllVendors(orgId));
         model.addAttribute("frequencyUnits",
                 FrequencyUnit.values());
         LocalDate today = LocalDate.now();

--- a/src/main/java/solutions/mystuff/application/web/ServiceSummaryPdf.java
+++ b/src/main/java/solutions/mystuff/application/web/ServiceSummaryPdf.java
@@ -1,18 +1,13 @@
 package solutions.mystuff.application.web;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import solutions.mystuff.domain.model.ServiceSchedule;
 import com.lowagie.text.Document;
 import com.lowagie.text.Element;
-import com.lowagie.text.Font;
-import com.lowagie.text.FontFactory;
 import com.lowagie.text.PageSize;
 import com.lowagie.text.Paragraph;
-import com.lowagie.text.Phrase;
-import com.lowagie.text.pdf.PdfPCell;
 import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfWriter;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,30 +16,10 @@ import jakarta.servlet.http.HttpServletResponse;
  * Generates a PDF report of service schedules due soon
  * using OpenPDF.
  *
- * <div class="mermaid">
- * sequenceDiagram
- *     ReportController->>ServiceSummaryPdf: write(response, schedules, cutoff, ...)
- *     ServiceSummaryPdf->>Document: org header, cutoff title, schedule table
- *     ServiceSummaryPdf-->>Browser: PDF via HttpServletResponse
- * </div>
- *
  * @see ReportController
+ * @see PdfHelper
  */
 final class ServiceSummaryPdf {
-
-    private static final DateTimeFormatter FMT =
-            DateTimeFormatter.ofPattern("MMM d, yyyy");
-    private static final Font TITLE_FONT =
-            FontFactory.getFont(
-                    FontFactory.HELVETICA_BOLD, 16);
-    private static final Font HEADER_FONT =
-            FontFactory.getFont(
-                    FontFactory.HELVETICA_BOLD, 10);
-    private static final Font BODY_FONT =
-            FontFactory.getFont(
-                    FontFactory.HELVETICA, 10);
-    private static final java.awt.Color HEADER_BG =
-            new java.awt.Color(220, 220, 220);
 
     private ServiceSummaryPdf() {
     }
@@ -64,29 +39,16 @@ final class ServiceSummaryPdf {
         PdfWriter.getInstance(doc,
                 response.getOutputStream());
         doc.open();
-        addOrgHeader(doc, orgName, username);
+        PdfHelper.addOrgHeader(doc, orgName, username);
         addTitle(doc, orgName, cutoff);
         if (schedules.isEmpty()) {
             doc.add(new Paragraph(
-                    "No service due.", BODY_FONT));
+                    "No service due.",
+                    PdfHelper.BODY_FONT));
         } else {
             doc.add(buildTable(schedules));
         }
         doc.close();
-    }
-
-    private static void addOrgHeader(
-            Document doc, String orgName,
-            String username) throws Exception {
-        Paragraph org = new Paragraph(
-                orgName, HEADER_FONT);
-        org.setAlignment(Element.ALIGN_LEFT);
-        doc.add(org);
-        Paragraph user = new Paragraph(
-                username, BODY_FONT);
-        user.setAlignment(Element.ALIGN_LEFT);
-        user.setSpacingAfter(8);
-        doc.add(user);
     }
 
     private static void addTitle(
@@ -95,15 +57,16 @@ final class ServiceSummaryPdf {
         Paragraph title = new Paragraph(
                 orgName
                         + " — Service Due Through "
-                        + cutoff.format(FMT),
-                TITLE_FONT);
+                        + cutoff.format(PdfHelper.FMT),
+                PdfHelper.TITLE_FONT);
         title.setAlignment(Element.ALIGN_CENTER);
         title.setSpacingAfter(4);
         doc.add(title);
         Paragraph gen = new Paragraph(
                 "Generated "
-                        + LocalDate.now().format(FMT),
-                BODY_FONT);
+                        + LocalDate.now().format(
+                                PdfHelper.FMT),
+                PdfHelper.BODY_FONT);
         gen.setAlignment(Element.ALIGN_RIGHT);
         gen.setSpacingAfter(12);
         doc.add(gen);
@@ -115,8 +78,8 @@ final class ServiceSummaryPdf {
         PdfPTable table = new PdfPTable(
                 new float[]{3, 2, 2, 2, 2, 2, 2});
         table.setWidthPercentage(100);
-        addHeaderRow(table, "Item", "Location",
-                "Service Type", "Vendor",
+        PdfHelper.addHeaderRow(table, "Item",
+                "Location", "Service Type", "Vendor",
                 "Next Due", "Frequency",
                 "Last Completed");
         for (ServiceSchedule s : schedules) {
@@ -127,46 +90,23 @@ final class ServiceSummaryPdf {
 
     private static void addRow(
             PdfPTable table, ServiceSchedule s) {
-        addCell(table, s.getItem().getName());
-        addCell(table, safe(
-                s.getItem().getLocation()));
-        addCell(table, s.getServiceType());
-        addCell(table,
+        PdfHelper.addCell(table,
+                s.getItem().getName());
+        PdfHelper.addCell(table,
+                PdfHelper.safe(
+                        s.getItem().getLocation()));
+        PdfHelper.addCell(table, s.getServiceType());
+        PdfHelper.addCell(table,
                 s.getPreferredVendor() != null
                         ? s.getPreferredVendor().getName()
                         : "");
-        addCell(table, fmtDate(s.getNextDueDate()));
-        addCell(table,
+        PdfHelper.addCell(table,
+                PdfHelper.fmtDate(s.getNextDueDate()));
+        PdfHelper.addCell(table,
                 "Every " + s.getFrequencyInterval()
                         + " " + s.getFrequencyUnit());
-        addCell(table,
-                fmtDate(s.getLastCompletedDate()));
-    }
-
-    private static void addHeaderRow(
-            PdfPTable table, String... headers) {
-        for (String h : headers) {
-            PdfPCell cell = new PdfPCell(
-                    new Phrase(h, HEADER_FONT));
-            cell.setBackgroundColor(HEADER_BG);
-            cell.setPadding(5);
-            table.addCell(cell);
-        }
-    }
-
-    private static void addCell(
-            PdfPTable table, String text) {
-        PdfPCell cell = new PdfPCell(
-                new Phrase(text, BODY_FONT));
-        cell.setPadding(4);
-        table.addCell(cell);
-    }
-
-    private static String fmtDate(LocalDate date) {
-        return date != null ? date.format(FMT) : "";
-    }
-
-    private static String safe(String val) {
-        return val != null ? val : "";
+        PdfHelper.addCell(table,
+                PdfHelper.fmtDate(
+                        s.getLastCompletedDate()));
     }
 }

--- a/src/main/java/solutions/mystuff/application/web/VendorController.java
+++ b/src/main/java/solutions/mystuff/application/web/VendorController.java
@@ -6,8 +6,10 @@ import java.util.Collections;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.AppUser;
+import solutions.mystuff.domain.model.VendorData;
 import solutions.mystuff.domain.port.in.VendorImportExport;
 import solutions.mystuff.domain.port.in.VendorManagement;
+import solutions.mystuff.domain.port.in.VendorQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -24,14 +26,6 @@ import org.springframework.web.multipart.MultipartFile;
 /**
  * Handles vendor CRUD, import, and export at /vendors endpoints.
  *
- * <div class="mermaid">
- * sequenceDiagram
- *     Browser->>VendorController: GET /vendors
- *     VendorController->>ControllerHelper: resolveUser(principal)
- *     VendorController->>VendorManagement: findAllVendors()
- *     VendorController-->>Browser: Thymeleaf vendors view
- * </div>
- *
  * @see ControllerHelper
  * @see VendorManagement
  * @see VendorImportExport
@@ -45,14 +39,17 @@ public class VendorController {
 
     private final ControllerHelper helper;
     private final VendorManagement vendorService;
+    private final VendorQuery vendorQuery;
     private final VendorImportExport importExport;
 
     public VendorController(
             ControllerHelper helper,
             VendorManagement vendorService,
+            VendorQuery vendorQuery,
             VendorImportExport importExport) {
         this.helper = helper;
         this.vendorService = vendorService;
+        this.vendorQuery = vendorQuery;
         this.importExport = importExport;
     }
 
@@ -68,7 +65,7 @@ public class VendorController {
         try {
             helper.addUserAttrs(user, model);
             model.addAttribute("vendors",
-                    vendorService.findAllVendors(
+                    vendorQuery.findAllVendors(
                             user.getOrganization()
                                     .getId()));
             return "vendors";
@@ -103,10 +100,11 @@ public class VendorController {
         try {
             UUID orgId =
                     user.getOrganization().getId();
-            vendorService.updateVendor(orgId, null,
+            VendorData data = new VendorData(
                     name, phone, email, addressLine1,
                     addressLine2, city, stateProvince,
                     postalCode, country, website, notes);
+            vendorService.createVendor(orgId, data);
             return "redirect:/vendors";
         } finally {
             helper.clearOrgMdc();
@@ -140,10 +138,12 @@ public class VendorController {
         try {
             UUID orgId =
                     user.getOrganization().getId();
-            vendorService.updateVendor(orgId, vendorId,
+            VendorData data = new VendorData(
                     name, phone, email, addressLine1,
                     addressLine2, city, stateProvince,
                     postalCode, country, website, notes);
+            vendorService.updateVendor(
+                    orgId, vendorId, data);
             return "redirect:/vendors";
         } finally {
             helper.clearOrgMdc();

--- a/src/main/java/solutions/mystuff/domain/model/FrequencyUnit.java
+++ b/src/main/java/solutions/mystuff/domain/model/FrequencyUnit.java
@@ -1,16 +1,47 @@
 package solutions.mystuff.domain.model;
 
+import java.time.LocalDate;
+
 /**
  * Time unit for recurring service schedule frequency.
  *
  * <p>Used by {@link ServiceSchedule} to express how often a service
- * recurs (e.g. every 3 {@code months}).
+ * recurs (e.g. every 3 {@code months}). Each constant knows how to
+ * advance a date by a given interval.
  *
  * @see ServiceSchedule
  */
 public enum FrequencyUnit {
-    days,
-    weeks,
-    months,
-    years
+    days {
+        @Override
+        public LocalDate advance(
+                LocalDate from, int interval) {
+            return from.plusDays(interval);
+        }
+    },
+    weeks {
+        @Override
+        public LocalDate advance(
+                LocalDate from, int interval) {
+            return from.plusWeeks(interval);
+        }
+    },
+    months {
+        @Override
+        public LocalDate advance(
+                LocalDate from, int interval) {
+            return from.plusMonths(interval);
+        }
+    },
+    years {
+        @Override
+        public LocalDate advance(
+                LocalDate from, int interval) {
+            return from.plusYears(interval);
+        }
+    };
+
+    /** Advance the given date by the specified interval. */
+    public abstract LocalDate advance(
+            LocalDate from, int interval);
 }

--- a/src/main/java/solutions/mystuff/domain/model/ParsedAltPhone.java
+++ b/src/main/java/solutions/mystuff/domain/model/ParsedAltPhone.java
@@ -1,0 +1,9 @@
+package solutions.mystuff.domain.model;
+
+/**
+ * A single alternate phone number parsed from a vCard TEL property.
+ *
+ * @see ParsedVCard
+ */
+public record ParsedAltPhone(String phone, String label) {
+}

--- a/src/main/java/solutions/mystuff/domain/model/ParsedVCard.java
+++ b/src/main/java/solutions/mystuff/domain/model/ParsedVCard.java
@@ -1,0 +1,24 @@
+package solutions.mystuff.domain.model;
+
+import java.util.List;
+
+/**
+ * Typed representation of a parsed vCard contact, replacing
+ * untyped {@code Map<String, Object>} returns from the parser.
+ *
+ * @see ParsedAltPhone
+ */
+public record ParsedVCard(
+        String name,
+        String phone,
+        String email,
+        String addressLine1,
+        String addressLine2,
+        String city,
+        String stateProvince,
+        String postalCode,
+        String country,
+        String website,
+        String notes,
+        List<ParsedAltPhone> altPhones) {
+}

--- a/src/main/java/solutions/mystuff/domain/model/ServiceRecord.java
+++ b/src/main/java/solutions/mystuff/domain/model/ServiceRecord.java
@@ -72,6 +72,9 @@ public class ServiceRecord extends OrgOwnedEntity {
     @Column(precision = 12, scale = 2)
     private BigDecimal cost;
 
+    @Column(name = "technician_name", length = 200)
+    private String technicianName;
+
     /** Set the data-entry timestamp and delegate to the base persist callback. */
     @Override
     @PrePersist
@@ -154,5 +157,13 @@ public class ServiceRecord extends OrgOwnedEntity {
 
     public void setCost(BigDecimal cost) {
         this.cost = cost;
+    }
+
+    public String getTechnicianName() {
+        return technicianName;
+    }
+
+    public void setTechnicianName(String technicianName) {
+        this.technicianName = technicianName;
     }
 }

--- a/src/main/java/solutions/mystuff/domain/model/ServiceSchedule.java
+++ b/src/main/java/solutions/mystuff/domain/model/ServiceSchedule.java
@@ -163,16 +163,8 @@ public class ServiceSchedule extends OrgOwnedEntity {
         this.lastCompletedDate = completedDate;
         if (frequencyUnit != null
                 && frequencyInterval != null) {
-            this.nextDueDate = switch (frequencyUnit) {
-                case days -> completedDate
-                        .plusDays(frequencyInterval);
-                case weeks -> completedDate
-                        .plusWeeks(frequencyInterval);
-                case months -> completedDate
-                        .plusMonths(frequencyInterval);
-                case years -> completedDate
-                        .plusYears(frequencyInterval);
-            };
+            this.nextDueDate = frequencyUnit.advance(
+                    completedDate, frequencyInterval);
         }
     }
 }

--- a/src/main/java/solutions/mystuff/domain/model/Validation.java
+++ b/src/main/java/solutions/mystuff/domain/model/Validation.java
@@ -1,0 +1,43 @@
+package solutions.mystuff.domain.model;
+
+/**
+ * Shared validation helpers usable by both domain services
+ * and the web layer, eliminating duplicated checks.
+ */
+public final class Validation {
+
+    private Validation() {
+    }
+
+    /** Validates that the value is not null or blank; returns trimmed value. */
+    public static String requireNotBlank(
+            String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(
+                    fieldName + " is required");
+        }
+        return value.trim();
+    }
+
+    /** Validates that the trimmed value does not exceed the maximum length. */
+    public static void requireMaxLength(
+            String value, String fieldName,
+            int maxLength) {
+        if (value != null
+                && value.trim().length() > maxLength) {
+            throw new IllegalArgumentException(
+                    fieldName
+                            + " exceeds maximum length of "
+                            + maxLength);
+        }
+    }
+
+    /** Validates that the integer value is at least 1. */
+    public static void requirePositive(
+            int value, String fieldName) {
+        if (value < 1) {
+            throw new IllegalArgumentException(
+                    fieldName + " must be at least 1");
+        }
+    }
+}

--- a/src/main/java/solutions/mystuff/domain/model/VendorData.java
+++ b/src/main/java/solutions/mystuff/domain/model/VendorData.java
@@ -1,0 +1,21 @@
+package solutions.mystuff.domain.model;
+
+/**
+ * Value object carrying vendor field values for create and
+ * update operations, avoiding long parameter lists on ports.
+ *
+ * @see Vendor
+ */
+public record VendorData(
+        String name,
+        String phone,
+        String email,
+        String addressLine1,
+        String addressLine2,
+        String city,
+        String stateProvince,
+        String postalCode,
+        String country,
+        String website,
+        String notes) {
+}

--- a/src/main/java/solutions/mystuff/domain/port/in/ItemQuery.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/ItemQuery.java
@@ -8,24 +8,9 @@ import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.ServiceRecord;
 import solutions.mystuff.domain.model.ServiceSchedule;
-import solutions.mystuff.domain.model.Vendor;
 
 /**
  * Inbound port for read-only item queries.
- *
- * <div class="mermaid">
- * classDiagram
- *     class ItemQuery {
- *         +findByOrganization(UUID, int, int) PageResult
- *         +searchByOrganization(UUID, String, int, int) PageResult
- *         +findAllByOrganization(UUID) List
- *         +findByIdAndOrganization(UUID, UUID) Optional
- *         +findRecordsByItem(UUID, UUID) List
- *         +findSchedulesByItem(UUID, UUID) List
- *         +findVendorsByOrganization(UUID) List
- *     }
- *     ItemQueryService ..|> ItemQuery
- * </div>
  *
  * @see solutions.mystuff.domain.model.Item
  */
@@ -53,7 +38,4 @@ public interface ItemQuery {
     /** Find service schedules for an item. */
     List<ServiceSchedule> findSchedulesByItem(
             UUID itemId, UUID orgId);
-
-    /** Find all vendors for an organization. */
-    List<Vendor> findVendorsByOrganization(UUID orgId);
 }

--- a/src/main/java/solutions/mystuff/domain/port/in/ScheduleLifecycle.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/ScheduleLifecycle.java
@@ -53,4 +53,12 @@ public interface ScheduleLifecycle {
     /** Deactivate a schedule so it no longer triggers. */
     void deactivateSchedule(
             UUID scheduleId, UUID orgId);
+
+    /**
+     * Complete the soonest active schedule for an item,
+     * or create a one-off record if no active schedule exists.
+     */
+    void completeNextForItem(UUID orgId, UUID itemId,
+            Vendor vendor, String summary,
+            LocalDate serviceDate, String techName);
 }

--- a/src/main/java/solutions/mystuff/domain/port/in/VendorManagement.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/VendorManagement.java
@@ -1,44 +1,29 @@
 package solutions.mystuff.domain.port.in;
 
-import java.util.List;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Vendor;
+import solutions.mystuff.domain.model.VendorData;
 
 /**
- * Inbound port for vendor CRUD operations.
- *
- * <div class="mermaid">
- * classDiagram
- *     class VendorManagement {
- *         +resolveVendor(UUID, String, String, String) Vendor
- *         +updateVendor(UUID, UUID, String, ...) Vendor
- *         +deleteVendor(UUID, UUID) void
- *         +findAllVendors(UUID) List~Vendor~
- *     }
- *     VendorManagementService ..|> VendorManagement
- * </div>
+ * Inbound port for vendor command operations (create, update, delete).
  *
  * @see solutions.mystuff.domain.model.Vendor
+ * @see VendorData
  */
 public interface VendorManagement {
 
-    /** Resolve an existing vendor by ID or create a new one. */
-    Vendor resolveVendor(UUID orgId, String vendorId,
-            String newVendorName,
-            String newVendorPhone);
+    /** Create a new vendor with all fields. */
+    Vendor createVendor(UUID orgId, VendorData data);
+
+    /** Create a new vendor with just name and phone (inline creation). */
+    Vendor createVendor(UUID orgId, String name,
+            String phone);
 
     /** Update all fields on an existing vendor. */
     Vendor updateVendor(UUID orgId, UUID vendorId,
-            String name, String phone, String email,
-            String addressLine1, String addressLine2,
-            String city, String stateProvince,
-            String postalCode, String country,
-            String website, String notes);
+            VendorData data);
 
     /** Delete a vendor by ID. */
     void deleteVendor(UUID orgId, UUID vendorId);
-
-    /** Find all vendors for an organization. */
-    List<Vendor> findAllVendors(UUID orgId);
 }

--- a/src/main/java/solutions/mystuff/domain/port/in/VendorQuery.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/VendorQuery.java
@@ -1,0 +1,17 @@
+package solutions.mystuff.domain.port.in;
+
+import java.util.List;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.Vendor;
+
+/**
+ * Inbound port for read-only vendor queries.
+ *
+ * @see solutions.mystuff.domain.model.Vendor
+ */
+public interface VendorQuery {
+
+    /** Find all vendors for an organization. */
+    List<Vendor> findAllVendors(UUID orgId);
+}

--- a/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
@@ -3,6 +3,7 @@ package solutions.mystuff.domain.service;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.Validation;
 import solutions.mystuff.domain.port.in.ItemManagement;
 import solutions.mystuff.domain.port.out.ItemRepository;
 import org.slf4j.Logger;
@@ -13,13 +14,6 @@ import org.springframework.transaction.annotation
 
 /**
  * Validates and persists new items within a transaction.
- *
- * <div class="mermaid">
- * sequenceDiagram
- *     Controller->>ItemManagementService: createItem(...)
- *     ItemManagementService->>ItemManagementService: validate fields
- *     ItemManagementService->>ItemRepository: save(item)
- * </div>
  *
  * @see ItemManagement
  * @see ItemRepository
@@ -47,12 +41,18 @@ public class ItemManagementService
             UUID orgId, String name,
             String location, String manufacturer,
             String modelName, String serialNumber) {
-        String trimName = requireNotBlank(name);
-        requireMaxLength(trimName, "Item name");
-        requireMaxLength(location, "Location");
-        requireMaxLength(manufacturer, "Manufacturer");
-        requireMaxLength(modelName, "Model name");
-        requireMaxLength(serialNumber, "Serial number");
+        String trimName = Validation.requireNotBlank(
+                name, "Item name");
+        Validation.requireMaxLength(
+                trimName, "Item name", MAX_LENGTH);
+        Validation.requireMaxLength(
+                location, "Location", MAX_LENGTH);
+        Validation.requireMaxLength(
+                manufacturer, "Manufacturer", MAX_LENGTH);
+        Validation.requireMaxLength(
+                modelName, "Model name", MAX_LENGTH);
+        Validation.requireMaxLength(
+                serialNumber, "Serial number", MAX_LENGTH);
 
         Item item = new Item();
         item.setOrganizationId(orgId);
@@ -62,24 +62,6 @@ public class ItemManagementService
         Item saved = itemRepo.save(item);
         log.info("Created item {}", saved.getName());
         return saved;
-    }
-
-    private String requireNotBlank(String value) {
-        if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException(
-                    "Item name is required");
-        }
-        return value.trim();
-    }
-
-    private void requireMaxLength(
-            String value, String field) {
-        if (value != null
-                && value.trim().length() > MAX_LENGTH) {
-            throw new IllegalArgumentException(
-                    field + " exceeds maximum length of "
-                            + MAX_LENGTH);
-        }
     }
 
     private void setIfPresent(

--- a/src/main/java/solutions/mystuff/domain/service/ItemQueryService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ItemQueryService.java
@@ -8,25 +8,16 @@ import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.ServiceRecord;
 import solutions.mystuff.domain.model.ServiceSchedule;
-import solutions.mystuff.domain.model.Vendor;
 import solutions.mystuff.domain.port.in.ItemQuery;
 import solutions.mystuff.domain.port.out.ItemRepository;
 import solutions.mystuff.domain.port.out
         .ServiceRecordRepository;
 import solutions.mystuff.domain.port.out
         .ServiceScheduleRepository;
-import solutions.mystuff.domain.port.out.VendorRepository;
 import org.springframework.stereotype.Service;
 
 /**
  * Delegates item read queries to outbound repository ports.
- *
- * <div class="mermaid">
- * sequenceDiagram
- *     Controller->>ItemQueryService: findByOrganization(...)
- *     ItemQueryService->>ItemRepository: delegate
- *     ItemRepository-->>Controller: result
- * </div>
  *
  * @see ItemQuery
  */
@@ -36,17 +27,14 @@ public class ItemQueryService implements ItemQuery {
     private final ItemRepository itemRepo;
     private final ServiceRecordRepository recordRepo;
     private final ServiceScheduleRepository scheduleRepo;
-    private final VendorRepository vendorRepo;
 
     public ItemQueryService(
             ItemRepository itemRepo,
             ServiceRecordRepository recordRepo,
-            ServiceScheduleRepository scheduleRepo,
-            VendorRepository vendorRepo) {
+            ServiceScheduleRepository scheduleRepo) {
         this.itemRepo = itemRepo;
         this.recordRepo = recordRepo;
         this.scheduleRepo = scheduleRepo;
-        this.vendorRepo = vendorRepo;
     }
 
     /** {@inheritDoc} */
@@ -95,12 +83,5 @@ public class ItemQueryService implements ItemQuery {
         return scheduleRepo
                 .findByItemIdAndOrganizationId(
                         itemId, orgId);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public List<Vendor> findVendorsByOrganization(
-            UUID orgId) {
-        return vendorRepo.findByOrganizationId(orgId);
     }
 }

--- a/src/main/java/solutions/mystuff/domain/service/ProfileImageServiceImpl.java
+++ b/src/main/java/solutions/mystuff/domain/service/ProfileImageServiceImpl.java
@@ -90,10 +90,9 @@ public class ProfileImageServiceImpl
         userRepo.save(user);
     }
 
-    /** Validates content type and size, then resizes the image to 128x128. */
+    /** Validates size and resizes the image to 128x128. */
     byte[] resizeImage(
             byte[] imageData, String contentType) {
-        validateType(contentType);
         if (imageData.length > MAX_BYTES) {
             throw new IllegalArgumentException(
                     "Image exceeds maximum size of "

--- a/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
+++ b/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
@@ -66,8 +66,7 @@ public class RecordCreationService
         record.setServiceDate(serviceDate);
         record.setSummary(summary.trim());
         if (techName != null && !techName.isBlank()) {
-            record.setDescription(
-                    "Technician: " + techName.trim());
+            record.setTechnicianName(techName.trim());
         }
         recordRepo.save(record);
         log.info("Saved service record for item {}",

--- a/src/main/java/solutions/mystuff/domain/service/ScheduleLifecycleService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ScheduleLifecycleService.java
@@ -1,6 +1,8 @@
 package solutions.mystuff.domain.service;
 
 import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.FrequencyUnit;
@@ -12,6 +14,7 @@ import solutions.mystuff.domain.port.in.ScheduleLifecycle;
 import solutions.mystuff.domain.port.out.ItemRepository;
 import solutions.mystuff.domain.port.out
         .ServiceScheduleRepository;
+import solutions.mystuff.domain.port.in.ItemQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -49,14 +52,17 @@ public class ScheduleLifecycleService
     private final ServiceScheduleRepository scheduleRepo;
     private final ItemRepository itemRepo;
     private final RecordCreation recordCreation;
+    private final ItemQuery itemQuery;
 
     public ScheduleLifecycleService(
             ServiceScheduleRepository scheduleRepo,
             ItemRepository itemRepo,
-            RecordCreation recordCreation) {
+            RecordCreation recordCreation,
+            ItemQuery itemQuery) {
         this.scheduleRepo = scheduleRepo;
         this.itemRepo = itemRepo;
         this.recordCreation = recordCreation;
+        this.itemQuery = itemQuery;
     }
 
     /** Creates a new service schedule for the given item. */
@@ -162,6 +168,34 @@ public class ScheduleLifecycleService
         scheduleRepo.save(sched);
         log.info("Deactivated schedule {}",
                 scheduleId);
+    }
+
+    @Override
+    @Transactional
+    public void completeNextForItem(
+            UUID orgId, UUID itemId, Vendor vendor,
+            String summary, LocalDate serviceDate,
+            String techName) {
+        List<ServiceSchedule> schedules =
+                itemQuery.findSchedulesByItem(
+                        itemId, orgId);
+        ServiceSchedule next = schedules.stream()
+                .filter(ServiceSchedule::isActive)
+                .min(Comparator.comparing(
+                        s -> s.getNextDueDate() != null
+                                ? s.getNextDueDate()
+                                : LocalDate.MAX))
+                .orElse(null);
+        if (next != null) {
+            completeSchedule(next.getId(), orgId,
+                    vendor, summary, serviceDate,
+                    techName);
+        } else {
+            Item item = findItem(itemId, orgId);
+            recordCreation.createRecord(orgId, item,
+                    null, null, vendor, summary,
+                    serviceDate, techName);
+        }
     }
 
     private ServiceSchedule findSchedule(

--- a/src/main/java/solutions/mystuff/domain/service/VCardParser.java
+++ b/src/main/java/solutions/mystuff/domain/service/VCardParser.java
@@ -6,14 +6,15 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import solutions.mystuff.domain.model.ParsedAltPhone;
+import solutions.mystuff.domain.model.ParsedVCard;
+
 /**
- * Parses vCard 4.0 (RFC 6350) content into structured maps.
- *
- * <p>Handles line unfolding, property parameter parsing, value
- * unescaping, case-insensitive property names, and both CRLF
- * and LF line endings. Skips vCards without an FN property.
+ * Parses vCard 4.0 (RFC 6350) content into typed
+ * {@link ParsedVCard} records.
  *
  * @see VCardSerializer
+ * @see ParsedVCard
  */
 public final class VCardParser {
 
@@ -23,26 +24,63 @@ public final class VCardParser {
     }
 
     /**
-     * Parses vCard content into a list of property maps.
+     * Parses vCard content into a list of typed records.
      *
      * @param vcfContent the raw vCard file content
-     * @return list of maps with vendor field keys
+     * @return list of parsed vCards
      * @throws IllegalArgumentException if more than 100 vCards
      */
-    public static List<Map<String, Object>> parse(
+    public static List<ParsedVCard> parse(
             String vcfContent) {
         if (vcfContent == null || vcfContent.isBlank()) {
             return List.of();
         }
         String[] lines = unfold(vcfContent);
-        List<Map<String, Object>> results =
+        List<Map<String, Object>> rawResults =
                 new ArrayList<>();
         List<String> currentLines = null;
         for (String line : lines) {
             currentLines = processLine(
-                    line, currentLines, results);
+                    line, currentLines, rawResults);
         }
-        return results;
+        return rawResults.stream()
+                .map(VCardParser::toRecord)
+                .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ParsedVCard toRecord(
+            Map<String, Object> card) {
+        List<ParsedAltPhone> altPhones = new ArrayList<>();
+        List<Map<String, String>> rawAlts =
+                (List<Map<String, String>>)
+                        card.get("altPhones");
+        if (rawAlts != null) {
+            for (Map<String, String> alt : rawAlts) {
+                altPhones.add(new ParsedAltPhone(
+                        alt.get("phone"),
+                        alt.get("label")));
+            }
+        }
+        return new ParsedVCard(
+                str(card, "name"),
+                str(card, "phone"),
+                str(card, "email"),
+                str(card, "addressLine1"),
+                str(card, "addressLine2"),
+                str(card, "city"),
+                str(card, "stateProvince"),
+                str(card, "postalCode"),
+                str(card, "country"),
+                str(card, "website"),
+                str(card, "notes"),
+                altPhones);
+    }
+
+    private static String str(
+            Map<String, Object> card, String key) {
+        Object val = card.get(key);
+        return val != null ? val.toString() : null;
     }
 
     private static String[] unfold(String content) {

--- a/src/main/java/solutions/mystuff/domain/service/VendorImportExportService.java
+++ b/src/main/java/solutions/mystuff/domain/service/VendorImportExportService.java
@@ -2,10 +2,11 @@ package solutions.mystuff.domain.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.LogSanitizer;
+import solutions.mystuff.domain.model.ParsedAltPhone;
+import solutions.mystuff.domain.model.ParsedVCard;
 import solutions.mystuff.domain.model.Vendor;
 import solutions.mystuff.domain.model.VendorAltPhone;
 import solutions.mystuff.domain.port.in.VendorImportExport;
@@ -15,17 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Imports and exports vendors using vCard 4.0 format.
- *
- * <p>All imported fields are sanitized via {@link LogSanitizer}
- * and truncated to their database column maximum lengths.
- *
- * <div class="mermaid">
- * sequenceDiagram
- *     Controller->>VendorImportExportService: importVendors(...)
- *     VendorImportExportService->>VCardParser: parse(vcfContent)
- *     VendorImportExportService->>LogSanitizer: sanitize(field)
- *     VendorImportExportService->>VendorRepository: save(vendor)
- * </div>
  *
  * @see VendorImportExport
  * @see VCardSerializer
@@ -72,14 +62,14 @@ public class VendorImportExportService
             throw new IllegalArgumentException(
                     "File is empty");
         }
-        List<Map<String, Object>> cards =
+        List<ParsedVCard> cards =
                 VCardParser.parse(vcfContent);
         if (cards.isEmpty()) {
             throw new IllegalArgumentException(
                     "No valid contacts found in file");
         }
         List<Vendor> result = new ArrayList<>();
-        for (Map<String, Object> card : cards) {
+        for (ParsedVCard card : cards) {
             Vendor vendor = mapToVendor(orgId, card);
             addAltPhones(orgId, vendor, card);
             result.add(
@@ -88,24 +78,20 @@ public class VendorImportExportService
         return result;
     }
 
-    @SuppressWarnings("unchecked")
     private void addAltPhones(
             UUID orgId, Vendor vendor,
-            Map<String, Object> card) {
-        List<Map<String, String>> altList =
-                (List<Map<String, String>>)
-                        card.get("altPhones");
-        if (altList == null) {
+            ParsedVCard card) {
+        if (card.altPhones() == null) {
             return;
         }
-        for (Map<String, String> alt : altList) {
+        for (ParsedAltPhone alt : card.altPhones()) {
             VendorAltPhone altPhone =
                     new VendorAltPhone();
             altPhone.setPhone(sanitize(
-                    alt.get("phone"),
+                    alt.phone(),
                     VendorFieldLimits.MAX_PHONE));
             altPhone.setLabel(sanitize(
-                    alt.get("label"),
+                    alt.label(),
                     VendorFieldLimits.MAX_LABEL));
             altPhone.setOrganizationId(orgId);
             altPhone.setVendor(vendor);
@@ -114,55 +100,42 @@ public class VendorImportExportService
     }
 
     private Vendor mapToVendor(
-            UUID orgId, Map<String, Object> card) {
+            UUID orgId, ParsedVCard card) {
         Vendor v = new Vendor();
         v.setOrganizationId(orgId);
-        mapContactFields(v, card);
-        mapAddressFields(v, card);
-        v.setWebsite(sanitize(
-                str(card, "website"),
-                VendorFieldLimits.MAX_URL));
-        v.setNotes(sanitize(str(card, "notes"),
-                VendorFieldLimits.MAX_NOTES));
+        setVendorFields(v, card);
         v.setAltPhones(new ArrayList<>());
         return v;
     }
 
-    private void mapContactFields(
-            Vendor v, Map<String, Object> card) {
-        v.setName(sanitize(str(card, "name"),
+    private void setVendorFields(
+            Vendor v, ParsedVCard card) {
+        v.setName(sanitize(card.name(),
                 VendorFieldLimits.MAX_NAME));
-        v.setPhone(sanitize(str(card, "phone"),
+        v.setPhone(sanitize(card.phone(),
                 VendorFieldLimits.MAX_PHONE));
-        v.setEmail(sanitize(str(card, "email"),
+        v.setEmail(sanitize(card.email(),
                 VendorFieldLimits.MAX_EMAIL));
-    }
-
-    private void mapAddressFields(
-            Vendor v, Map<String, Object> card) {
         v.setAddressLine1(sanitize(
-                str(card, "addressLine1"),
+                card.addressLine1(),
                 VendorFieldLimits.MAX_ADDR));
         v.setAddressLine2(sanitize(
-                str(card, "addressLine2"),
+                card.addressLine2(),
                 VendorFieldLimits.MAX_ADDR));
-        v.setCity(sanitize(str(card, "city"),
+        v.setCity(sanitize(card.city(),
                 VendorFieldLimits.MAX_CITY));
         v.setStateProvince(sanitize(
-                str(card, "stateProvince"),
+                card.stateProvince(),
                 VendorFieldLimits.MAX_STATE));
         v.setPostalCode(sanitize(
-                str(card, "postalCode"),
+                card.postalCode(),
                 VendorFieldLimits.MAX_POSTAL));
-        v.setCountry(sanitize(
-                str(card, "country"),
+        v.setCountry(sanitize(card.country(),
                 VendorFieldLimits.MAX_COUNTRY));
-    }
-
-    private String str(
-            Map<String, Object> card, String key) {
-        Object val = card.get(key);
-        return val != null ? val.toString() : null;
+        v.setWebsite(sanitize(card.website(),
+                VendorFieldLimits.MAX_URL));
+        v.setNotes(sanitize(card.notes(),
+                VendorFieldLimits.MAX_NOTES));
     }
 
     private String sanitize(

--- a/src/main/java/solutions/mystuff/domain/service/VendorManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/VendorManagementService.java
@@ -3,30 +3,26 @@ package solutions.mystuff.domain.service;
 import java.util.List;
 import java.util.UUID;
 
+import solutions.mystuff.domain.model.Validation;
 import solutions.mystuff.domain.model.Vendor;
+import solutions.mystuff.domain.model.VendorData;
 import solutions.mystuff.domain.port.in.VendorManagement;
+import solutions.mystuff.domain.port.in.VendorQuery;
 import solutions.mystuff.domain.port.out.VendorRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation
+        .Transactional;
 
 /**
- * Resolves, creates, updates, and deletes vendors.
- *
- * <div class="mermaid">
- * sequenceDiagram
- *     Controller->>VendorManagementService: resolveVendor(...)
- *     alt vendorId == "__new__"
- *         VendorManagementService->>VendorRepository: save(newVendor)
- *     else existing vendor
- *         VendorManagementService->>VendorRepository: findByIdAndOrganizationId(...)
- *     end
- * </div>
+ * Creates, updates, deletes, and queries vendors.
  *
  * @see VendorManagement
+ * @see VendorQuery
  * @see VendorRepository
  */
 @Service
 public class VendorManagementService
-        implements VendorManagement {
+        implements VendorManagement, VendorQuery {
 
     private final VendorRepository vendorRepository;
 
@@ -36,64 +32,40 @@ public class VendorManagementService
     }
 
     @Override
-    public Vendor resolveVendor(
-            UUID orgId, String vendorId,
-            String newVendorName,
-            String newVendorPhone) {
-        if ("__new__".equals(vendorId)) {
-            return createVendor(orgId,
-                    newVendorName, newVendorPhone);
+    public Vendor createVendor(
+            UUID orgId, VendorData data) {
+        Validation.requireNotBlank(
+                data.name(), "Vendor name");
+        Vendor vendor = newVendor(orgId);
+        applyFields(vendor, data);
+        return vendorRepository.save(vendor);
+    }
+
+    @Override
+    public Vendor createVendor(
+            UUID orgId, String name, String phone) {
+        Validation.requireNotBlank(name, "Vendor name");
+        Validation.requireMaxLength(name, "Vendor name",
+                VendorFieldLimits.MAX_NAME);
+        Validation.requireMaxLength(phone, "Vendor phone",
+                VendorFieldLimits.MAX_PHONE);
+        Vendor vendor = newVendor(orgId);
+        vendor.setName(name.trim());
+        if (phone != null && !phone.isBlank()) {
+            vendor.setPhone(phone.trim());
         }
-        if (vendorId != null && !vendorId.isBlank()) {
-            return findVendor(orgId,
-                    UUID.fromString(vendorId));
-        }
-        return null;
+        return vendorRepository.save(vendor);
     }
 
     @Override
     public Vendor updateVendor(
             UUID orgId, UUID vendorId,
-            String name, String phone, String email,
-            String addressLine1, String addressLine2,
-            String city, String stateProvince,
-            String postalCode, String country,
-            String website, String notes) {
-        requireName(name);
-        Vendor vendor = vendorId != null
-                ? findVendor(orgId, vendorId)
-                : newVendor(orgId);
-        applyFields(vendor, name, phone, email,
-                addressLine1, addressLine2, city,
-                stateProvince, postalCode, country,
-                website, notes);
+            VendorData data) {
+        Validation.requireNotBlank(
+                data.name(), "Vendor name");
+        Vendor vendor = findVendor(orgId, vendorId);
+        applyFields(vendor, data);
         return vendorRepository.save(vendor);
-    }
-
-    private Vendor newVendor(UUID orgId) {
-        Vendor v = new Vendor();
-        v.setOrganizationId(orgId);
-        return v;
-    }
-
-    private void applyFields(
-            Vendor v, String name, String phone,
-            String email, String addressLine1,
-            String addressLine2, String city,
-            String stateProvince, String postalCode,
-            String country, String website,
-            String notes) {
-        v.setName(name.trim());
-        v.setPhone(trimOrNull(phone));
-        v.setEmail(trimOrNull(email));
-        v.setAddressLine1(trimOrNull(addressLine1));
-        v.setAddressLine2(trimOrNull(addressLine2));
-        v.setCity(trimOrNull(city));
-        v.setStateProvince(trimOrNull(stateProvince));
-        v.setPostalCode(trimOrNull(postalCode));
-        v.setCountry(trimOrNull(country));
-        v.setWebsite(trimOrNull(website));
-        v.setNotes(trimOrNull(notes));
     }
 
     @Override
@@ -105,25 +77,34 @@ public class VendorManagementService
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Vendor> findAllVendors(UUID orgId) {
         return vendorRepository
                 .findByOrganizationId(orgId);
     }
 
-    private Vendor createVendor(
-            UUID orgId, String name, String phone) {
-        requireName(name);
-        requireMaxLength(name, "Vendor name",
-                VendorFieldLimits.MAX_NAME);
-        requireMaxLength(phone, "Vendor phone",
-                VendorFieldLimits.MAX_PHONE);
-        Vendor vendor = new Vendor();
-        vendor.setOrganizationId(orgId);
-        vendor.setName(name.trim());
-        if (phone != null && !phone.isBlank()) {
-            vendor.setPhone(phone.trim());
-        }
-        return vendorRepository.save(vendor);
+    private Vendor newVendor(UUID orgId) {
+        Vendor v = new Vendor();
+        v.setOrganizationId(orgId);
+        return v;
+    }
+
+    private void applyFields(
+            Vendor v, VendorData data) {
+        v.setName(data.name().trim());
+        v.setPhone(trimOrNull(data.phone()));
+        v.setEmail(trimOrNull(data.email()));
+        v.setAddressLine1(
+                trimOrNull(data.addressLine1()));
+        v.setAddressLine2(
+                trimOrNull(data.addressLine2()));
+        v.setCity(trimOrNull(data.city()));
+        v.setStateProvince(
+                trimOrNull(data.stateProvince()));
+        v.setPostalCode(trimOrNull(data.postalCode()));
+        v.setCountry(trimOrNull(data.country()));
+        v.setWebsite(trimOrNull(data.website()));
+        v.setNotes(trimOrNull(data.notes()));
     }
 
     private Vendor findVendor(
@@ -134,23 +115,6 @@ public class VendorManagementService
                 .orElseThrow(() ->
                         new IllegalArgumentException(
                                 "Vendor not found"));
-    }
-
-    private void requireName(String name) {
-        if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException(
-                    "Vendor name is required");
-        }
-    }
-
-    private void requireMaxLength(
-            String value, String field, int max) {
-        if (value != null
-                && value.trim().length() > max) {
-            throw new IllegalArgumentException(
-                    field + " exceeds maximum length"
-                            + " of " + max);
-        }
     }
 
     private String trimOrNull(String value) {

--- a/src/main/java/solutions/mystuff/infrastructure/persistence/JpaItemRepositoryAdapter.java
+++ b/src/main/java/solutions/mystuff/infrastructure/persistence/JpaItemRepositoryAdapter.java
@@ -53,7 +53,7 @@ public class JpaItemRepositoryAdapter
             UUID organizationId, int page, int size) {
         Page<Item> p = delegate.findByOrganizationId(
                 organizationId, pageOf(page, size));
-        return toPageResult(p);
+        return PageResultConverter.toPageResult(p);
     }
 
     /** {@inheritDoc} */
@@ -71,7 +71,7 @@ public class JpaItemRepositoryAdapter
             int page, int size) {
         Page<Item> p = delegate.searchByOrganizationId(
                 organizationId, query, pageOf(page, size));
-        return toPageResult(p);
+        return PageResultConverter.toPageResult(p);
     }
 
     /** {@inheritDoc} */
@@ -93,12 +93,4 @@ public class JpaItemRepositoryAdapter
                 Sort.by("name").ascending());
     }
 
-    private <T> PageResult<T> toPageResult(Page<T> p) {
-        return new PageResult<>(
-                p.getContent(),
-                p.getNumber(),
-                p.getSize(),
-                p.getTotalElements(),
-                p.getTotalPages());
-    }
 }

--- a/src/main/java/solutions/mystuff/infrastructure/persistence/JpaScheduleRepositoryAdapter.java
+++ b/src/main/java/solutions/mystuff/infrastructure/persistence/JpaScheduleRepositoryAdapter.java
@@ -66,7 +66,7 @@ public class JpaScheduleRepositoryAdapter
                 delegate.findActiveByOrgId(
                         organizationId,
                         PageRequest.of(page, size));
-        return toPageResult(p);
+        return PageResultConverter.toPageResult(p);
     }
 
     /** {@inheritDoc} */
@@ -94,12 +94,4 @@ public class JpaScheduleRepositoryAdapter
         return delegate.save(schedule);
     }
 
-    private <T> PageResult<T> toPageResult(Page<T> p) {
-        return new PageResult<>(
-                p.getContent(),
-                p.getNumber(),
-                p.getSize(),
-                p.getTotalElements(),
-                p.getTotalPages());
-    }
 }

--- a/src/main/java/solutions/mystuff/infrastructure/persistence/PageResultConverter.java
+++ b/src/main/java/solutions/mystuff/infrastructure/persistence/PageResultConverter.java
@@ -1,0 +1,24 @@
+package solutions.mystuff.infrastructure.persistence;
+
+import solutions.mystuff.domain.model.PageResult;
+import org.springframework.data.domain.Page;
+
+/**
+ * Converts Spring Data {@link Page} to the domain
+ * {@link PageResult}, keeping Spring Data types out of
+ * the domain layer.
+ */
+final class PageResultConverter {
+
+    private PageResultConverter() {
+    }
+
+    static <T> PageResult<T> toPageResult(Page<T> page) {
+        return new PageResult<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages());
+    }
+}

--- a/src/main/resources/db/migration/V10__add_technician_name_to_service_records.sql
+++ b/src/main/resources/db/migration/V10__add_technician_name_to_service_records.sql
@@ -1,0 +1,7 @@
+ALTER TABLE service_records
+    ADD COLUMN technician_name VARCHAR(200);
+
+-- Migrate existing technician data from description field
+UPDATE service_records
+SET technician_name = SUBSTRING(description FROM 14)
+WHERE description LIKE 'Technician: %';

--- a/src/test/java/solutions/mystuff/domain/model/FrequencyUnitTest.java
+++ b/src/test/java/solutions/mystuff/domain/model/FrequencyUnitTest.java
@@ -1,5 +1,7 @@
 package solutions.mystuff.domain.model;
 
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -25,5 +27,37 @@ class FrequencyUnitTest {
                 FrequencyUnit.valueOf("months"));
         assertEquals(FrequencyUnit.years,
                 FrequencyUnit.valueOf("years"));
+    }
+
+    @Test
+    @DisplayName("should advance by days")
+    void shouldAdvanceByDays() {
+        LocalDate date = LocalDate.of(2026, 3, 10);
+        assertEquals(LocalDate.of(2026, 3, 24),
+                FrequencyUnit.days.advance(date, 14));
+    }
+
+    @Test
+    @DisplayName("should advance by weeks")
+    void shouldAdvanceByWeeks() {
+        LocalDate date = LocalDate.of(2026, 3, 10);
+        assertEquals(LocalDate.of(2026, 3, 24),
+                FrequencyUnit.weeks.advance(date, 2));
+    }
+
+    @Test
+    @DisplayName("should advance by months")
+    void shouldAdvanceByMonths() {
+        LocalDate date = LocalDate.of(2026, 3, 10);
+        assertEquals(LocalDate.of(2026, 9, 10),
+                FrequencyUnit.months.advance(date, 6));
+    }
+
+    @Test
+    @DisplayName("should advance by years")
+    void shouldAdvanceByYears() {
+        LocalDate date = LocalDate.of(2026, 3, 10);
+        assertEquals(LocalDate.of(2027, 3, 10),
+                FrequencyUnit.years.advance(date, 1));
     }
 }

--- a/src/test/java/solutions/mystuff/domain/service/ItemQueryServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ItemQueryServiceTest.java
@@ -7,13 +7,11 @@ import java.util.UUID;
 import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.UuidV7;
-import solutions.mystuff.domain.model.Vendor;
 import solutions.mystuff.domain.port.out.ItemRepository;
 import solutions.mystuff.domain.port.out
         .ServiceRecordRepository;
 import solutions.mystuff.domain.port.out
         .ServiceScheduleRepository;
-import solutions.mystuff.domain.port.out.VendorRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -32,11 +30,9 @@ class ItemQueryServiceTest {
             mock(ServiceRecordRepository.class);
     private final ServiceScheduleRepository schedRepo =
             mock(ServiceScheduleRepository.class);
-    private final VendorRepository vendorRepo =
-            mock(VendorRepository.class);
     private final ItemQueryService service =
             new ItemQueryService(itemRepo, recordRepo,
-                    schedRepo, vendorRepo);
+                    schedRepo);
 
     private final UUID orgId = UuidV7.generate();
 
@@ -102,16 +98,5 @@ class ItemQueryServiceTest {
         verify(schedRepo)
                 .findByItemIdAndOrganizationId(
                         itemId, orgId);
-    }
-
-    @Test
-    @DisplayName("should delegate findVendorsByOrganization")
-    void shouldDelegateFindVendors() {
-        Vendor v = new Vendor();
-        when(vendorRepo.findByOrganizationId(orgId))
-                .thenReturn(List.of(v));
-        assertEquals(1,
-                service.findVendorsByOrganization(orgId)
-                        .size());
     }
 }

--- a/src/test/java/solutions/mystuff/domain/service/RecordCreationServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/RecordCreationServiceTest.java
@@ -49,8 +49,8 @@ class RecordCreationServiceTest {
         ServiceRecord saved = captor.getValue();
         assertThat(saved.getSummary())
                 .isEqualTo("Replaced filter");
-        assertThat(saved.getDescription())
-                .isEqualTo("Technician: John");
+        assertThat(saved.getTechnicianName())
+                .isEqualTo("John");
     }
 
     @Test
@@ -69,7 +69,7 @@ class RecordCreationServiceTest {
                 ArgumentCaptor.forClass(
                         ServiceRecord.class);
         verify(repo).save(captor.capture());
-        assertThat(captor.getValue().getDescription())
+        assertThat(captor.getValue().getTechnicianName())
                 .isNull();
     }
 

--- a/src/test/java/solutions/mystuff/domain/service/ScheduleLifecycleServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ScheduleLifecycleServiceTest.java
@@ -8,6 +8,7 @@ import solutions.mystuff.domain.model.FrequencyUnit;
 import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.ServiceSchedule;
 import solutions.mystuff.domain.model.Vendor;
+import solutions.mystuff.domain.port.in.ItemQuery;
 import solutions.mystuff.domain.port.in.RecordCreation;
 import solutions.mystuff.domain.port.out.ItemRepository;
 import solutions.mystuff.domain.port.out
@@ -33,10 +34,12 @@ class ScheduleLifecycleServiceTest {
             mock(ItemRepository.class);
     private final RecordCreation recordCreation =
             mock(RecordCreation.class);
+    private final ItemQuery itemQuery =
+            mock(ItemQuery.class);
     private final ScheduleLifecycleService service =
             new ScheduleLifecycleService(
                     schedRepo, itemRepo,
-                    recordCreation);
+                    recordCreation, itemQuery);
 
     private final UUID orgId = UUID.randomUUID();
 

--- a/src/test/java/solutions/mystuff/domain/service/VCardParserTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/VCardParserTest.java
@@ -1,8 +1,9 @@
 package solutions.mystuff.domain.service;
 
 import java.util.List;
-import java.util.Map;
 
+import solutions.mystuff.domain.model.ParsedAltPhone;
+import solutions.mystuff.domain.model.ParsedVCard;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -13,18 +14,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("VCardParser")
-@SuppressWarnings("unchecked")
 class VCardParserTest {
 
     @Test
     @DisplayName("should parse minimal vCard")
     void shouldParseMinimal() {
         String vcf = vcard("FN:Acme Corp\r\n");
-        List<Map<String, Object>> result =
+        List<ParsedVCard> result =
                 VCardParser.parse(vcf);
         assertEquals(1, result.size());
         assertEquals("Acme Corp",
-                result.get(0).get("name"));
+                result.get(0).name());
     }
 
     @Test
@@ -33,9 +33,9 @@ class VCardParserTest {
         String vcf = vcard(
                 "FN:Test\r\n"
                         + "TEL;TYPE=work:555-0100\r\n");
-        Map<String, Object> card =
+        ParsedVCard card =
                 VCardParser.parse(vcf).get(0);
-        assertEquals("555-0100", card.get("phone"));
+        assertEquals("555-0100", card.phone());
     }
 
     @Test
@@ -44,10 +44,9 @@ class VCardParserTest {
         String vcf = vcard(
                 "FN:Test\r\n"
                         + "EMAIL:info@test.com\r\n");
-        Map<String, Object> card =
+        ParsedVCard card =
                 VCardParser.parse(vcf).get(0);
-        assertEquals("info@test.com",
-                card.get("email"));
+        assertEquals("info@test.com", card.email());
     }
 
     @Test
@@ -58,19 +57,16 @@ class VCardParserTest {
                         + "ADR;TYPE=work:;Suite 100"
                         + ";123 Main;Springfield"
                         + ";IL;62701;US\r\n");
-        Map<String, Object> card =
+        ParsedVCard card =
                 VCardParser.parse(vcf).get(0);
         assertEquals("123 Main",
-                card.get("addressLine1"));
+                card.addressLine1());
         assertEquals("Suite 100",
-                card.get("addressLine2"));
-        assertEquals("Springfield",
-                card.get("city"));
-        assertEquals("IL",
-                card.get("stateProvince"));
-        assertEquals("62701",
-                card.get("postalCode"));
-        assertEquals("US", card.get("country"));
+                card.addressLine2());
+        assertEquals("Springfield", card.city());
+        assertEquals("IL", card.stateProvince());
+        assertEquals("62701", card.postalCode());
+        assertEquals("US", card.country());
     }
 
     @Test
@@ -79,10 +75,10 @@ class VCardParserTest {
         String vcf = vcard(
                 "FN:Test\r\n"
                         + "URL:https://test.com\r\n");
-        Map<String, Object> card =
+        ParsedVCard card =
                 VCardParser.parse(vcf).get(0);
         assertEquals("https://test.com",
-                card.get("website"));
+                card.website());
     }
 
     @Test
@@ -91,10 +87,9 @@ class VCardParserTest {
         String vcf = vcard(
                 "FN:Test\r\n"
                         + "NOTE:Good vendor\r\n");
-        Map<String, Object> card =
+        ParsedVCard card =
                 VCardParser.parse(vcf).get(0);
-        assertEquals("Good vendor",
-                card.get("notes"));
+        assertEquals("Good vendor", card.notes());
     }
 
     @Test
@@ -105,18 +100,16 @@ class VCardParserTest {
                         + "TEL;TYPE=work:555-0001\r\n"
                         + "TEL;TYPE=mobile:555-0002\r\n"
                         + "TEL;TYPE=fax:555-0003\r\n");
-        Map<String, Object> card =
+        ParsedVCard card =
                 VCardParser.parse(vcf).get(0);
-        assertEquals("555-0001", card.get("phone"));
-        List<Map<String, String>> alts =
-                (List<Map<String, String>>)
-                        card.get("altPhones");
+        assertEquals("555-0001", card.phone());
+        List<ParsedAltPhone> alts = card.altPhones();
         assertNotNull(alts);
         assertEquals(2, alts.size());
         assertEquals("555-0002",
-                alts.get(0).get("phone"));
+                alts.get(0).phone());
         assertEquals("mobile",
-                alts.get(0).get("label"));
+                alts.get(0).label());
     }
 
     @Test
@@ -125,12 +118,10 @@ class VCardParserTest {
         String vcf = vcard(
                 "FN:Acme\\; Inc\\\\\r\n"
                         + "NOTE:Line1\\nLine2\r\n");
-        Map<String, Object> card =
+        ParsedVCard card =
                 VCardParser.parse(vcf).get(0);
-        assertEquals("Acme; Inc\\",
-                card.get("name"));
-        assertEquals("Line1\nLine2",
-                card.get("notes"));
+        assertEquals("Acme; Inc\\", card.name());
+        assertEquals("Line1\nLine2", card.notes());
     }
 
     @Test
@@ -139,10 +130,10 @@ class VCardParserTest {
         String vcf = vcard(
                 "FN:Very Long \r\n"
                         + " Name Here\r\n");
-        Map<String, Object> card =
+        ParsedVCard card =
                 VCardParser.parse(vcf).get(0);
         assertEquals("Very Long Name Here",
-                card.get("name"));
+                card.name());
     }
 
     @Test
@@ -152,7 +143,7 @@ class VCardParserTest {
                 + "VERSION:4.0\r\n"
                 + "TEL:555-0100\r\n"
                 + "END:VCARD\r\n";
-        List<Map<String, Object>> result =
+        List<ParsedVCard> result =
                 VCardParser.parse(vcf);
         assertTrue(result.isEmpty());
     }
@@ -162,13 +153,11 @@ class VCardParserTest {
     void shouldParseMultiple() {
         String vcf = vcard("FN:Alpha\r\n")
                 + vcard("FN:Beta\r\n");
-        List<Map<String, Object>> result =
+        List<ParsedVCard> result =
                 VCardParser.parse(vcf);
         assertEquals(2, result.size());
-        assertEquals("Alpha",
-                result.get(0).get("name"));
-        assertEquals("Beta",
-                result.get(1).get("name"));
+        assertEquals("Alpha", result.get(0).name());
+        assertEquals("Beta", result.get(1).name());
     }
 
     @Test
@@ -178,7 +167,7 @@ class VCardParserTest {
                 + "VERSION:4.0\n"
                 + "FN:Test\n"
                 + "END:VCARD\n";
-        List<Map<String, Object>> result =
+        List<ParsedVCard> result =
                 VCardParser.parse(vcf);
         assertEquals(1, result.size());
     }
@@ -190,7 +179,7 @@ class VCardParserTest {
                 + "version:4.0\r\n"
                 + "fn:Test\r\n"
                 + "end:vcard\r\n";
-        List<Map<String, Object>> result =
+        List<ParsedVCard> result =
                 VCardParser.parse(vcf);
         assertEquals(1, result.size());
     }
@@ -212,15 +201,15 @@ class VCardParserTest {
         String vcf = vcard(
                 "FN:Test\r\n"
                         + "TEL:555-0001\r\n");
-        Map<String, Object> card =
+        ParsedVCard card =
                 VCardParser.parse(vcf).get(0);
-        assertEquals("555-0001", card.get("phone"));
+        assertEquals("555-0001", card.phone());
     }
 
     @Test
     @DisplayName("should handle empty input")
     void shouldHandleEmptyInput() {
-        List<Map<String, Object>> result =
+        List<ParsedVCard> result =
                 VCardParser.parse("");
         assertTrue(result.isEmpty());
     }
@@ -232,10 +221,9 @@ class VCardParserTest {
                 "FN:Test\r\n"
                         + "X-CUSTOM:value\r\n"
                         + "BDAY:19700101\r\n");
-        Map<String, Object> card =
+        ParsedVCard card =
                 VCardParser.parse(vcf).get(0);
-        assertEquals("Test", card.get("name"));
-        assertNull(card.get("X-CUSTOM"));
+        assertEquals("Test", card.name());
     }
 
     private String vcard(String properties) {

--- a/src/test/java/solutions/mystuff/domain/service/VendorManagementServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/VendorManagementServiceTest.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Vendor;
+import solutions.mystuff.domain.model.VendorData;
 import solutions.mystuff.domain.port.out.VendorRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,38 +30,13 @@ class VendorManagementServiceTest {
     private final UUID orgId = UUID.randomUUID();
 
     @Test
-    @DisplayName("should resolve existing vendor by ID")
-    void shouldResolveExisting() {
-        UUID vendorId = UUID.randomUUID();
-        Vendor vendor = new Vendor();
-        vendor.setName("Existing");
-        when(repo.findByIdAndOrganizationId(
-                vendorId, orgId))
-                .thenReturn(Optional.of(vendor));
-
-        Vendor result = service.resolveVendor(
-                orgId, vendorId.toString(), null, null);
-
-        assertThat(result.getName())
-                .isEqualTo("Existing");
-    }
-
-    @Test
-    @DisplayName("should return null for blank vendor ID")
-    void shouldReturnNullForBlank() {
-        Vendor result = service.resolveVendor(
-                orgId, null, null, null);
-        assertThat(result).isNull();
-    }
-
-    @Test
-    @DisplayName("should create new vendor")
-    void shouldCreateNewVendor() {
+    @DisplayName("should create vendor with name and phone")
+    void shouldCreateWithNameAndPhone() {
         when(repo.save(any(Vendor.class)))
                 .thenAnswer(i -> i.getArgument(0));
 
-        Vendor result = service.resolveVendor(
-                orgId, "__new__", "Acme", "555-1234");
+        Vendor result = service.createVendor(
+                orgId, "Acme", "555-1234");
 
         assertThat(result.getName()).isEqualTo("Acme");
         assertThat(result.getPhone())
@@ -69,44 +45,26 @@ class VendorManagementServiceTest {
     }
 
     @Test
-    @DisplayName("should reject blank vendor name")
-    void shouldRejectBlankName() {
+    @DisplayName("should reject blank vendor name on inline create")
+    void shouldRejectBlankNameInline() {
         assertThatThrownBy(() ->
-                service.resolveVendor(
-                        orgId, "__new__", "  ", null))
+                service.createVendor(
+                        orgId, "  ", null))
                 .isInstanceOf(
                         IllegalArgumentException.class)
                 .hasMessageContaining("required");
     }
 
     @Test
-    @DisplayName("should reject long vendor name")
-    void shouldRejectLongName() {
+    @DisplayName("should reject long vendor name on inline create")
+    void shouldRejectLongNameInline() {
         String longName = "x".repeat(201);
         assertThatThrownBy(() ->
-                service.resolveVendor(
-                        orgId, "__new__",
-                        longName, null))
+                service.createVendor(
+                        orgId, longName, null))
                 .isInstanceOf(
                         IllegalArgumentException.class)
                 .hasMessageContaining("maximum length");
-    }
-
-    @Test
-    @DisplayName("should throw when vendor not found")
-    void shouldThrowWhenNotFound() {
-        UUID vendorId = UUID.randomUUID();
-        when(repo.findByIdAndOrganizationId(
-                vendorId, orgId))
-                .thenReturn(Optional.empty());
-
-        assertThatThrownBy(() ->
-                service.resolveVendor(
-                        orgId, vendorId.toString(),
-                        null, null))
-                .isInstanceOf(
-                        IllegalArgumentException.class)
-                .hasMessage("Vendor not found");
     }
 
     @Test
@@ -120,11 +78,13 @@ class VendorManagementServiceTest {
         when(repo.save(any(Vendor.class)))
                 .thenAnswer(i -> i.getArgument(0));
 
+        VendorData data = new VendorData(
+                "Updated", "555-9999", "new@test.com",
+                "456 Oak", "Apt 2", "Chicago", "IL",
+                "60601", "US", "https://updated.com",
+                "Great vendor");
         Vendor result = service.updateVendor(
-                orgId, vendorId, "Updated", "555-9999",
-                "new@test.com", "456 Oak", "Apt 2",
-                "Chicago", "IL", "60601", "US",
-                "https://updated.com", "Great vendor");
+                orgId, vendorId, data);
 
         assertThat(result.getName())
                 .isEqualTo("Updated");
@@ -147,11 +107,13 @@ class VendorManagementServiceTest {
         when(repo.save(any(Vendor.class)))
                 .thenAnswer(i -> i.getArgument(0));
 
-        Vendor result = service.updateVendor(
-                orgId, null, "New Corp", "555-1111",
-                "info@new.com", "789 Pine", null,
-                "Boston", "MA", "02101", "US",
-                "https://new.com", "Notes here");
+        VendorData data = new VendorData(
+                "New Corp", "555-1111", "info@new.com",
+                "789 Pine", null, "Boston", "MA",
+                "02101", "US", "https://new.com",
+                "Notes here");
+        Vendor result = service.createVendor(
+                orgId, data);
 
         assertThat(result.getName())
                 .isEqualTo("New Corp");
@@ -165,11 +127,12 @@ class VendorManagementServiceTest {
     @DisplayName("should reject blank name on update")
     void shouldRejectBlankNameOnUpdate() {
         UUID vendorId = UUID.randomUUID();
+        VendorData data = new VendorData(
+                "  ", null, null, null, null,
+                null, null, null, null, null, null);
         assertThatThrownBy(() ->
                 service.updateVendor(
-                        orgId, vendorId, "  ", null,
-                        null, null, null, null,
-                        null, null, null, null, null))
+                        orgId, vendorId, data))
                 .isInstanceOf(
                         IllegalArgumentException.class)
                 .hasMessageContaining("required");
@@ -183,11 +146,12 @@ class VendorManagementServiceTest {
                 vendorId, orgId))
                 .thenReturn(Optional.empty());
 
+        VendorData data = new VendorData(
+                "Name", null, null, null, null,
+                null, null, null, null, null, null);
         assertThatThrownBy(() ->
                 service.updateVendor(
-                        orgId, vendorId, "Name", null,
-                        null, null, null, null,
-                        null, null, null, null, null))
+                        orgId, vendorId, data))
                 .isInstanceOf(
                         IllegalArgumentException.class)
                 .hasMessage("Vendor not found");

--- a/src/test/java/solutions/mystuff/infrastructure/config/SecurityConfigurationTest.java
+++ b/src/test/java/solutions/mystuff/infrastructure/config/SecurityConfigurationTest.java
@@ -3,22 +3,61 @@ package solutions.mystuff.infrastructure.config;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.autoconfigure
+        .EnableAutoConfiguration;
+import org.springframework.boot.data.jpa.autoconfigure
+        .DataJpaRepositoriesAutoConfiguration;
+import org.springframework.boot.flyway.autoconfigure
+        .FlywayAutoConfiguration;
+import org.springframework.boot.hibernate.autoconfigure
+        .HibernateJpaAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure
+        .DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure
+        .AutoConfigureMockMvc;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.security.test.web.servlet
+        .request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request
+        .MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result
+        .MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result
+        .MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(
+        classes = SecurityConfigurationTest.TestConfig.class)
 @AutoConfigureMockMvc
 @DisplayName("Security Configuration")
 class SecurityConfigurationTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Configuration
+    @EnableAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class,
+        FlywayAutoConfiguration.class,
+        DataJpaRepositoriesAutoConfiguration.class
+    })
+    @Import(SecurityConfiguration.class)
+    static class TestConfig {
+
+        @RestController
+        static class StubController {
+            @GetMapping("/items")
+            String items() {
+                return "ok";
+            }
+        }
+    }
 
     @Test
     @DisplayName("should allow unauthenticated health endpoint")


### PR DESCRIPTION
- SRP: Extract VendorQuery port, shared Validation utility, PdfHelper
- OCP: Move date advancement into FrequencyUnit enum, registry-based error advice
- ISP: Introduce VendorData/ParsedVCard value objects, split vendor query/command ports
- DIP: Replace Map<String,Object> with typed records in VCardParser
- Extract PageResultConverter, remove duplicate validation logic
- Add technician_name column with Flyway migration (V10)
- Fix SecurityConfigurationTest to not require database connection