### PR TITLE
Require pull requests for all changes (ADR-0028)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,11 +257,24 @@ Transitive dependencies, managed by Spring Boot 4.0.3 BOM unless version noted.
 |---------|---------|-----------|
 | htmx | 2.0.4 | CDN `<script>` in layout.html |
 
-## Workflow After Commits
+## Development Workflow
 
-After every commit, push and rebuild/rerun docker:
+All changes go through pull requests — no direct commits to `main` ([ADR-0028](doc/adr/0028-require-pull-requests-for-all-changes.md)).
+
 ```bash
-git push && docker compose up -d --build app
+# 1. Create a branch
+git checkout -b descriptive-branch-name
+
+# 2. Work, commit, push
+git push -u origin descriptive-branch-name
+
+# 3. After each commit, rebuild docker for local testing
+docker compose up -d --build app
+
+# 4. Create PR when ready
+gh pr create
+
+# 5. Merge after CI passes (merge commit, not squash)
 ```
 
 ## ADRs

--- a/doc/adr/0028-require-pull-requests-for-all-changes.md
+++ b/doc/adr/0028-require-pull-requests-for-all-changes.md
@@ -1,0 +1,26 @@
+# 28. Require pull requests for all changes
+
+Date: 2026-03-17
+
+## Status
+
+Accepted
+
+## Context
+
+Direct commits to `main` bypass CI checks and code review, increasing the risk of broken builds, regressions, and undocumented changes reaching production.
+
+## Decision
+
+1. **No direct commits to `main`** — all code changes must go through a pull request, including bug fixes, documentation updates, and CI workflow changes.
+2. **Branch naming** — use descriptive branch names (e.g., `add-schedule-editing`, `fix-vendor-lazy-load`). No long-lived feature branches; keep PRs small and focused.
+3. **CI must pass** — the GitHub Actions build (compile, checkstyle, tests, coverage) must succeed before merging.
+4. **Merge strategy** — use merge commits (not squash or rebase) to preserve individual commit history in the PR.
+5. **Branch protection** — enable branch protection on `main` in GitHub to enforce these rules.
+
+## Consequences
+
+- Every change has a CI-verified build before it reaches `main`.
+- The commit history on `main` consists only of merge commits, making it easy to identify and revert entire features.
+- Developers must create a branch before starting work, even for small changes.
+- Emergency hotfixes still go through a PR, but the review can be expedited.


### PR DESCRIPTION
## Summary

- ADR-0028: all code changes must go through a pull request — no direct commits to main
- CLAUDE.md workflow section updated with branch-based development flow
- Branch protection should be enabled on main in GitHub settings

## Test plan

- [ ] Documentation-only change, no code affected
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)