### PR TITLE
Add Claude code review workflow for PRs

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,26 @@
+name: Code Review
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+    - name: Claude Code Review
+      uses: anthropics/claude-code-action@v1
+      with:
+        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        review_comment_prefix: "**Claude:**"
+        timeout_minutes: 10


### PR DESCRIPTION
## Summary

- New `.github/workflows/code-review.yml` runs `anthropics/claude-code-action@v1` on every PR targeting main
- Posts review comments prefixed with **Claude:**
- Requires `ANTHROPIC_API_KEY` secret in repo settings (Settings > Secrets and variables > Actions)

## Test plan

- [ ] Add `ANTHROPIC_API_KEY` secret to repo settings
- [ ] Merge this PR, then open a test PR to verify reviews appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)