### PR TITLE
Add cost input to service forms and expand service history display

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/ItemController.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemController.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.application.web;
 
+import java.math.BigDecimal;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -268,6 +269,10 @@ public class ItemController {
             @RequestParam(required = false,
                     defaultValue = "false")
                     boolean oneOff,
+            @Parameter(description = "Cost of the"
+                    + " service (optional)")
+            @RequestParam(required = false)
+                    BigDecimal cost,
             Principal principal) {
         AppUser user = helper.resolveUser(principal);
         helper.setOrgMdc(user);
@@ -281,11 +286,11 @@ public class ItemController {
         if (oneOff) {
             recordService.createRecord(orgId, item,
                     null, null, vendor, summary,
-                    date, techName);
+                    date, techName, cost);
         } else {
             scheduleService.completeNextForItem(
                     orgId, itemId, vendor,
-                    summary, date, techName);
+                    summary, date, techName, cost);
         }
         return "redirect:/items";
     }

--- a/src/main/java/solutions/mystuff/application/web/ItemHistoryPdf.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemHistoryPdf.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.application.web;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -175,27 +176,40 @@ final class ItemHistoryPdf {
             List<ServiceRecord> records)
             throws Exception {
         PdfPTable table = new PdfPTable(
-                new float[]{2, 2, 2, 2, 4});
+                new float[]{2, 2, 2, 2, 1, 3});
         table.setWidthPercentage(100);
         PdfHelper.addHeaderRow(table, "Date",
                 "Service Type", "Vendor", "Tech",
-                "Summary");
+                "Cost", "Summary");
         for (ServiceRecord r : records) {
-            PdfHelper.addCell(table,
-                    PdfHelper.fmtDate(
-                            r.getServiceDate()));
-            PdfHelper.addCell(table,
-                    PdfHelper.safe(r.getServiceType()));
-            PdfHelper.addCell(table,
-                    r.getVendor() != null
-                            ? r.getVendor().getName()
-                            : "");
-            PdfHelper.addCell(table,
-                    PdfHelper.safe(
-                            r.getTechnicianName()));
-            PdfHelper.addCell(table,
-                    PdfHelper.safe(r.getSummary()));
+            addRecordRow(table, r);
         }
         return table;
+    }
+
+    private static void addRecordRow(
+            PdfPTable table, ServiceRecord r) {
+        PdfHelper.addCell(table,
+                PdfHelper.fmtDate(r.getServiceDate()));
+        PdfHelper.addCell(table,
+                PdfHelper.safe(r.getServiceType()));
+        PdfHelper.addCell(table,
+                r.getVendor() != null
+                        ? r.getVendor().getName()
+                        : "");
+        PdfHelper.addCell(table,
+                PdfHelper.safe(
+                        r.getTechnicianName()));
+        PdfHelper.addCell(table, formatCost(r.getCost()));
+        PdfHelper.addCell(table,
+                PdfHelper.safe(r.getSummary()));
+    }
+
+    private static String formatCost(BigDecimal cost) {
+        if (cost == null
+                || cost.compareTo(BigDecimal.ZERO) == 0) {
+            return "";
+        }
+        return "$" + cost.setScale(2).toPlainString();
     }
 }

--- a/src/main/java/solutions/mystuff/application/web/ScheduleController.java
+++ b/src/main/java/solutions/mystuff/application/web/ScheduleController.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.application.web;
 
+import java.math.BigDecimal;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -148,6 +149,10 @@ public class ScheduleController {
             @Parameter(description = "Technician name")
             @RequestParam(required = false)
                     String techName,
+            @Parameter(description = "Cost of the"
+                    + " service (optional)")
+            @RequestParam(required = false)
+                    BigDecimal cost,
             @Parameter(description = "Set to 'item' to"
                     + " redirect to the item detail"
                     + " instead of /schedules")
@@ -165,7 +170,7 @@ public class ScheduleController {
         ServiceSchedule sched =
                 scheduleService.completeSchedule(
                         scheduleId, orgId, vendor,
-                        summary, date, techName);
+                        summary, date, techName, cost);
         if ("item".equals(redirectTo)) {
             return "redirect:/items/"
                     + sched.getItem().getId();

--- a/src/main/java/solutions/mystuff/domain/port/in/RecordCreation.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/RecordCreation.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.domain.port.in;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -13,7 +14,7 @@ import solutions.mystuff.domain.model.Vendor;
  * <div class="mermaid">
  * classDiagram
  *     class RecordCreation {
- *         +createRecord(UUID, Item, String, ServiceSchedule, Vendor, String, LocalDate, String) void
+ *         +createRecord(UUID, Item, String, ServiceSchedule, Vendor, String, LocalDate, String, BigDecimal) void
  *     }
  *     RecordCreationService ..|> RecordCreation
  * </div>
@@ -33,5 +34,5 @@ public interface RecordCreation {
             String serviceType,
             ServiceSchedule schedule, Vendor vendor,
             String summary, LocalDate serviceDate,
-            String techName);
+            String techName, BigDecimal cost);
 }

--- a/src/main/java/solutions/mystuff/domain/port/in/ScheduleLifecycle.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/ScheduleLifecycle.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.domain.port.in;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -14,7 +15,7 @@ import solutions.mystuff.domain.model.Vendor;
  * classDiagram
  *     class ScheduleLifecycle {
  *         +createSchedule(UUID, UUID, String, Vendor, LocalDate, int, FrequencyUnit) ServiceSchedule
- *         +completeSchedule(UUID, UUID, Vendor, String, LocalDate, String) ServiceSchedule
+ *         +completeSchedule(UUID, UUID, Vendor, String, LocalDate, String, BigDecimal) ServiceSchedule
  *         +skipSchedule(UUID, UUID) ServiceSchedule
  *         +editSchedule(UUID, UUID, String, LocalDate, int, FrequencyUnit, Vendor) ServiceSchedule
  *         +deactivateSchedule(UUID, UUID) void
@@ -36,7 +37,8 @@ public interface ScheduleLifecycle {
     /** Mark a schedule as completed and log the service. */
     ServiceSchedule completeSchedule(UUID scheduleId,
             UUID orgId, Vendor vendor, String summary,
-            LocalDate serviceDate, String techName);
+            LocalDate serviceDate, String techName,
+            BigDecimal cost);
 
     /** Skip the current occurrence and advance the due date. */
     ServiceSchedule skipSchedule(
@@ -60,5 +62,6 @@ public interface ScheduleLifecycle {
      */
     void completeNextForItem(UUID orgId, UUID itemId,
             Vendor vendor, String summary,
-            LocalDate serviceDate, String techName);
+            LocalDate serviceDate, String techName,
+            BigDecimal cost);
 }

--- a/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
+++ b/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.domain.service;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -54,7 +55,7 @@ public class RecordCreationService
             String serviceType,
             ServiceSchedule schedule, Vendor vendor,
             String summary, LocalDate serviceDate,
-            String techName) {
+            String techName, BigDecimal cost) {
         validateSummary(summary);
         validateTechName(techName);
         ServiceRecord record = new ServiceRecord();
@@ -68,6 +69,8 @@ public class RecordCreationService
         if (techName != null && !techName.isBlank()) {
             record.setTechnicianName(techName.trim());
         }
+        record.setCost(
+                cost != null ? cost : BigDecimal.ZERO);
         recordRepo.save(record);
         log.info("Saved service record for item {}",
                 item.getId());

--- a/src/main/java/solutions/mystuff/domain/service/ScheduleLifecycleService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ScheduleLifecycleService.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.domain.service;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
@@ -101,14 +102,15 @@ public class ScheduleLifecycleService
     public ServiceSchedule completeSchedule(
             UUID scheduleId, UUID orgId,
             Vendor vendor, String summary,
-            LocalDate serviceDate, String techName) {
+            LocalDate serviceDate, String techName,
+            BigDecimal cost) {
         ServiceSchedule sched =
                 findSchedule(scheduleId, orgId);
         recordCreation.createRecord(orgId,
                 sched.getItem(),
                 sched.getServiceType(), sched,
                 vendor, summary, serviceDate,
-                techName);
+                techName, cost);
         sched.advanceNextDueDate(serviceDate);
         ServiceSchedule saved =
                 scheduleRepo.save(sched);
@@ -178,7 +180,7 @@ public class ScheduleLifecycleService
     public void completeNextForItem(
             UUID orgId, UUID itemId, Vendor vendor,
             String summary, LocalDate serviceDate,
-            String techName) {
+            String techName, BigDecimal cost) {
         List<ServiceSchedule> schedules =
                 itemQuery.findSchedulesByItem(
                         itemId, orgId);
@@ -192,12 +194,12 @@ public class ScheduleLifecycleService
         if (next != null) {
             completeSchedule(next.getId(), orgId,
                     vendor, summary, serviceDate,
-                    techName);
+                    techName, cost);
         } else {
             Item item = findItem(itemId, orgId);
             recordCreation.createRecord(orgId, item,
                     null, null, vendor, summary,
-                    serviceDate, techName);
+                    serviceDate, techName, cost);
         }
     }
 

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -102,6 +102,9 @@
                             <th:block th:replace="~{fragments/vendor-select :: vendorFields(${vendors}, null, false)}"/>
                             <label>Tech <input type="text" name="techName"
                                                placeholder="Technician name"/></label>
+                            <label>Cost <input type="number" name="cost"
+                                               step="0.01" min="0"
+                                               placeholder="0.00"/></label>
                             <button type="submit" class="btn-icon btn-log">
                                 <svg th:replace="~{fragments/icons :: icon-checkmark}"></svg>
                                 Save
@@ -153,6 +156,8 @@
                                     <thead><tr>
                                         <th>Date</th><th>Service Type</th>
                                         <th>Summary</th><th>Details</th>
+                                        <th>Vendor</th><th>Technician</th>
+                                        <th>Cost</th>
                                     </tr></thead>
                                     <tbody>
                                     <tr th:each="r : ${itemRecords}">
@@ -160,6 +165,9 @@
                                         <td th:text="${r.serviceType}"></td>
                                         <td th:text="${r.summary}"></td>
                                         <td th:text="${r.description}"></td>
+                                        <td th:text="${r.vendor != null ? r.vendor.name : ''}"></td>
+                                        <td th:text="${r.technicianName != null ? r.technicianName : ''}"></td>
+                                        <td th:text="${r.cost != null and r.cost.compareTo(T(java.math.BigDecimal).ZERO) != 0 ? '$' + #numbers.formatDecimal(r.cost, 1, 2) : ''}"></td>
                                     </tr>
                                     </tbody>
                                 </table>
@@ -231,6 +239,10 @@
                                                 <label>Tech <input type="text"
                                                     name="techName"
                                                     placeholder="Technician name"/></label>
+                                                <label>Cost <input type="number"
+                                                    name="cost" step="0.01"
+                                                    min="0"
+                                                    placeholder="0.00"/></label>
                                                 <button type="submit"
                                                         class="btn-icon btn-log">
                                                     <svg th:replace="~{fragments/icons :: icon-checkmark}"></svg>

--- a/src/main/resources/templates/schedules.html
+++ b/src/main/resources/templates/schedules.html
@@ -83,6 +83,9 @@
                             <th:block th:replace="~{fragments/vendor-select :: vendorFields(${vendors}, ${s.preferredVendor}, false)}"/>
                             <label>Tech <input type="text" name="techName"
                                                placeholder="Technician name"/></label>
+                            <label>Cost <input type="number" name="cost"
+                                               step="0.01" min="0"
+                                               placeholder="0.00"/></label>
                             <button type="submit" class="btn-icon btn-log">
                                 <svg th:replace="~{fragments/icons :: icon-checkmark}"></svg>
                                 Save

--- a/src/test/java/solutions/mystuff/domain/service/RecordCreationServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/RecordCreationServiceTest.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.domain.service;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -40,7 +41,8 @@ class RecordCreationServiceTest {
         service.createRecord(orgId, item,
                 "Filter Change", null, null,
                 "Replaced filter",
-                LocalDate.of(2026, 3, 10), "John");
+                LocalDate.of(2026, 3, 10), "John",
+                new BigDecimal("50.00"));
 
         ArgumentCaptor<ServiceRecord> captor =
                 ArgumentCaptor.forClass(
@@ -63,7 +65,7 @@ class RecordCreationServiceTest {
 
         service.createRecord(orgId, item,
                 "Test", null, null, "Summary",
-                LocalDate.now(), "  ");
+                LocalDate.now(), "  ", null);
 
         ArgumentCaptor<ServiceRecord> captor =
                 ArgumentCaptor.forClass(
@@ -80,7 +82,7 @@ class RecordCreationServiceTest {
         assertThatThrownBy(() ->
                 service.createRecord(orgId, item,
                         "Test", null, null, "  ",
-                        LocalDate.now(), null))
+                        LocalDate.now(), null, null))
                 .isInstanceOf(
                         IllegalArgumentException.class)
                 .hasMessageContaining("required");
@@ -95,7 +97,7 @@ class RecordCreationServiceTest {
                 service.createRecord(orgId, item,
                         "Test", null, null,
                         longSummary,
-                        LocalDate.now(), null))
+                        LocalDate.now(), null, null))
                 .isInstanceOf(
                         IllegalArgumentException.class)
                 .hasMessageContaining("maximum length");
@@ -110,7 +112,8 @@ class RecordCreationServiceTest {
                 service.createRecord(orgId, item,
                         "Test", null, null,
                         "Summary",
-                        LocalDate.now(), longTech))
+                        LocalDate.now(), longTech,
+                        null))
                 .isInstanceOf(
                         IllegalArgumentException.class)
                 .hasMessageContaining("maximum length");

--- a/src/test/java/solutions/mystuff/domain/service/ScheduleLifecycleServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ScheduleLifecycleServiceTest.java
@@ -113,12 +113,12 @@ class ScheduleLifecycleServiceTest {
 
         LocalDate date = LocalDate.of(2026, 3, 10);
         service.completeSchedule(schedId, orgId,
-                null, "Done", date, null);
+                null, "Done", date, null, null);
 
         verify(recordCreation).createRecord(
                 eq(orgId), any(), any(), eq(sched),
                 eq(null), eq("Done"), eq(date),
-                eq(null));
+                eq(null), eq(null));
         verify(schedRepo).save(sched);
     }
 


### PR DESCRIPTION
Add cost input field to one-off service forms, schedule completion forms in both items.html and schedules.html. Thread the cost parameter through ItemController, ScheduleController, ScheduleLifecycle port, RecordCreation port, and their service implementations to persist on ServiceRecord.

Expand the item detail service history table to show vendor, technician, and cost columns. Add cost column to the PDF item history report.