### PR TITLE
Add item editing, richer detail fields, and category support

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/ItemController.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemController.java
@@ -28,6 +28,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation
         .RequestParam;
 
@@ -42,7 +43,7 @@ import org.springframework.web.bind.annotation
         description = "Item CRUD and service operations")
 public class ItemController {
 
-    private static final Logger log =
+    private static final Logger LOG =
             LoggerFactory.getLogger(ItemController.class);
 
     private final ControllerHelper helper;
@@ -203,13 +204,98 @@ public class ItemController {
                     + " (max 100 chars)")
             @RequestParam(required = false)
                     String serialNumber,
+            @Parameter(description = "Model number"
+                    + " (max 200 chars)")
+            @RequestParam(required = false)
+                    String modelNumber,
+            @Parameter(description = "Model year")
+            @RequestParam(required = false)
+                    Integer modelYear,
+            @Parameter(description = "Category"
+                    + " (max 100 chars)")
+            @RequestParam(required = false)
+                    String category,
+            @Parameter(description = "Purchase date"
+                    + " in ISO format (yyyy-MM-dd)")
+            @RequestParam(required = false)
+                    String purchaseDate,
+            @Parameter(description = "Free-text notes")
+            @RequestParam(required = false) String notes,
             Principal principal) {
         AppUser user = helper.resolveUser(principal);
         helper.setOrgMdc(user);
         UUID orgId = user.getOrganization().getId();
+        LocalDate pd = parseOptionalDate(purchaseDate);
         itemService.createItem(orgId, name,
-                location, manufacturer,
-                modelName, serialNumber);
+                location, manufacturer, modelName,
+                serialNumber, modelNumber, modelYear,
+                category, pd, notes);
+        return "redirect:/items";
+    }
+
+    @Operation(summary = "Update item",
+            description = "Updates an existing item."
+                    + " Redirects to /items on success.",
+            responses = {
+                    @ApiResponse(responseCode = "302",
+                            description = "Redirect to"
+                                    + " /items on"
+                                    + " success"),
+                    @ApiResponse(responseCode = "400",
+                            description = "Validation"
+                                    + " error"),
+                    @ApiResponse(responseCode = "404",
+                            description = "Item not"
+                                    + " found")})
+    @PutMapping("/items/{id}")
+    public String editItem(
+            @Parameter(description = "Item UUID")
+            @PathVariable("id") UUID itemId,
+            @Parameter(description = "Item name"
+                    + " (required, max 200 chars)",
+                    required = true)
+            @RequestParam String name,
+            @Parameter(description = "Location"
+                    + " (max 200 chars)")
+            @RequestParam(required = false)
+                    String location,
+            @Parameter(description = "Manufacturer"
+                    + " (max 200 chars)")
+            @RequestParam(required = false)
+                    String manufacturer,
+            @Parameter(description = "Model name"
+                    + " (max 200 chars)")
+            @RequestParam(required = false)
+                    String modelName,
+            @Parameter(description = "Model number"
+                    + " (max 200 chars)")
+            @RequestParam(required = false)
+                    String modelNumber,
+            @Parameter(description = "Model year")
+            @RequestParam(required = false)
+                    Integer modelYear,
+            @Parameter(description = "Serial number"
+                    + " (max 100 chars)")
+            @RequestParam(required = false)
+                    String serialNumber,
+            @Parameter(description = "Purchase date")
+            @RequestParam(required = false)
+                    String purchaseDate,
+            @Parameter(description = "Category"
+                    + " (max 100 chars)")
+            @RequestParam(required = false)
+                    String category,
+            @Parameter(description = "Free-text notes")
+            @RequestParam(required = false) String notes,
+            Principal principal) {
+        AppUser user = helper.resolveUser(principal);
+        helper.setOrgMdc(user);
+        UUID orgId = user.getOrganization().getId();
+        LocalDate pd = parseOptionalDate(purchaseDate);
+        itemService.updateItem(orgId, itemId, name,
+                location, manufacturer, modelName,
+                modelNumber, modelYear, serialNumber,
+                pd, category, notes);
         return "redirect:/items";
     }
 
@@ -386,13 +472,13 @@ public class ItemController {
         int safePage = Math.max(0, page);
         PageResult<Item> result;
         if (q != null && !q.isBlank()) {
-            log.info("Searching items query={}",
+            LOG.info("Searching items query={}",
                     LogSanitizer.sanitize(q));
             result = itemQuery.searchByOrganization(
                     orgId, q, safePage, safeSize);
             model.addAttribute("q", q);
         } else {
-            log.info("Listing items page={}", safePage);
+            LOG.info("Listing items page={}", safePage);
             result = itemQuery.findByOrganization(
                     orgId, safePage, safeSize);
         }
@@ -412,5 +498,13 @@ public class ItemController {
                 .orElseThrow(() ->
                         new NotFoundException(
                                 "Item not found"));
+    }
+
+    private LocalDate parseOptionalDate(String date) {
+        if (date == null || date.isBlank()) {
+            return null;
+        }
+        return InputValidator.parseDate(
+                date, "Purchase date");
     }
 }

--- a/src/main/java/solutions/mystuff/domain/model/Item.java
+++ b/src/main/java/solutions/mystuff/domain/model/Item.java
@@ -29,6 +29,7 @@ import jakarta.persistence.Table;
  *         String modelName
  *         Integer modelYear
  *         String serialNumber
+ *         String category
  *     }
  *     Item --|> OrgOwnedEntity
  *     Item "1" --> "*" ServiceSchedule
@@ -66,6 +67,9 @@ public class Item extends OrgOwnedEntity {
 
     @Column(name = "purchase_date")
     private LocalDate purchaseDate;
+
+    @Column(length = 100)
+    private String category;
 
     @Column(columnDefinition = "TEXT")
     private String notes;
@@ -144,6 +148,14 @@ public class Item extends OrgOwnedEntity {
 
     public void setPurchaseDate(LocalDate purchaseDate) {
         this.purchaseDate = purchaseDate;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
     }
 
     public String getNotes() {

--- a/src/main/java/solutions/mystuff/domain/model/ServiceRecord.java
+++ b/src/main/java/solutions/mystuff/domain/model/ServiceRecord.java
@@ -69,8 +69,8 @@ public class ServiceRecord extends OrgOwnedEntity {
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    @Column(precision = 12, scale = 2)
-    private BigDecimal cost;
+    @Column(precision = 12, scale = 2, nullable = false)
+    private BigDecimal cost = BigDecimal.ZERO;
 
     @Column(name = "technician_name", length = 200)
     private String technicianName;

--- a/src/main/java/solutions/mystuff/domain/port/in/ItemManagement.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/ItemManagement.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.domain.port.in;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
@@ -10,7 +11,8 @@ import solutions.mystuff.domain.model.Item;
  * <div class="mermaid">
  * classDiagram
  *     class ItemManagement {
- *         +createItem(UUID, String, String, String, String, String) Item
+ *         +createItem(UUID, String, String, String, String, String, String, Integer, String, LocalDate, String) Item
+ *         +updateItem(UUID, UUID, String, String, String, String, String, Integer, String, LocalDate, String, String) Item
  *     }
  *     ItemManagementService ..|> ItemManagement
  * </div>
@@ -22,6 +24,17 @@ public interface ItemManagement {
     /** Validate inputs and create a new item for the organization. */
     Item createItem(UUID orgId, String name,
             String location, String manufacturer,
-            String modelName, String serialNumber);
+            String modelName, String serialNumber,
+            String modelNumber, Integer modelYear,
+            String category, LocalDate purchaseDate,
+            String notes);
+
+    /** Validate inputs and update an existing item. */
+    Item updateItem(UUID orgId, UUID itemId,
+            String name, String location,
+            String manufacturer, String modelName,
+            String modelNumber, Integer modelYear,
+            String serialNumber, LocalDate purchaseDate,
+            String category, String notes);
 
 }

--- a/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
@@ -1,8 +1,10 @@
 package solutions.mystuff.domain.service;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.NotFoundException;
 import solutions.mystuff.domain.model.Validation;
 import solutions.mystuff.domain.port.in.ItemManagement;
 import solutions.mystuff.domain.port.out.ItemRepository;
@@ -13,7 +15,19 @@ import org.springframework.transaction.annotation
         .Transactional;
 
 /**
- * Validates and persists new items within a transaction.
+ * Validates and persists new or updated items within a transaction.
+ *
+ * <div class="mermaid">
+ * sequenceDiagram
+ *     participant C as Controller
+ *     participant S as ItemManagementService
+ *     participant R as ItemRepository
+ *     C-&gt;&gt;S: createItem / updateItem
+ *     S-&gt;&gt;S: validate fields
+ *     S-&gt;&gt;R: save(item)
+ *     R--&gt;&gt;S: saved item
+ *     S--&gt;&gt;C: Item
+ * </div>
  *
  * @see ItemManagement
  * @see ItemRepository
@@ -22,10 +36,11 @@ import org.springframework.transaction.annotation
 public class ItemManagementService
         implements ItemManagement {
 
-    private static final Logger log =
+    private static final Logger LOG =
             LoggerFactory.getLogger(
                     ItemManagementService.class);
     private static final int MAX_LENGTH = 200;
+    private static final int CATEGORY_MAX = 100;
 
     private final ItemRepository itemRepo;
 
@@ -40,7 +55,56 @@ public class ItemManagementService
     public Item createItem(
             UUID orgId, String name,
             String location, String manufacturer,
-            String modelName, String serialNumber) {
+            String modelName, String serialNumber,
+            String modelNumber, Integer modelYear,
+            String category, LocalDate purchaseDate,
+            String notes) {
+        String trimName = validateFields(name, location,
+                manufacturer, modelName, serialNumber,
+                modelNumber, category);
+        Item item = new Item();
+        item.setOrganizationId(orgId);
+        item.setName(trimName);
+        applyOptionalFields(item, location,
+                manufacturer, modelName, serialNumber,
+                modelNumber, modelYear, category,
+                purchaseDate, notes);
+        Item saved = itemRepo.save(item);
+        LOG.info("Created item {}", saved.getName());
+        return saved;
+    }
+
+    /** Finds existing item and updates all fields. */
+    @Override
+    @Transactional
+    public Item updateItem(
+            UUID orgId, UUID itemId,
+            String name, String location,
+            String manufacturer, String modelName,
+            String modelNumber, Integer modelYear,
+            String serialNumber, LocalDate purchaseDate,
+            String category, String notes) {
+        String trimName = validateFields(name, location,
+                manufacturer, modelName, serialNumber,
+                modelNumber, category);
+        Item item = itemRepo
+                .findByIdAndOrganizationId(itemId, orgId)
+                .orElseThrow(() -> new NotFoundException(
+                        "Item not found"));
+        item.setName(trimName);
+        setAllFields(item, location, manufacturer,
+                modelName, serialNumber, modelNumber,
+                modelYear, category, purchaseDate, notes);
+        Item saved = itemRepo.save(item);
+        LOG.info("Updated item {}", saved.getName());
+        return saved;
+    }
+
+    private String validateFields(
+            String name, String location,
+            String manufacturer, String modelName,
+            String serialNumber, String modelNumber,
+            String category) {
         String trimName = Validation.requireNotBlank(
                 name, "Item name");
         Validation.requireMaxLength(
@@ -53,21 +117,51 @@ public class ItemManagementService
                 modelName, "Model name", MAX_LENGTH);
         Validation.requireMaxLength(
                 serialNumber, "Serial number", MAX_LENGTH);
+        Validation.requireMaxLength(
+                modelNumber, "Model number", MAX_LENGTH);
+        Validation.requireMaxLength(
+                category, "Category", CATEGORY_MAX);
+        return trimName;
+    }
 
-        Item item = new Item();
-        item.setOrganizationId(orgId);
-        item.setName(trimName);
+    private void applyOptionalFields(
+            Item item, String location,
+            String manufacturer, String modelName,
+            String serialNumber, String modelNumber,
+            Integer modelYear, String category,
+            LocalDate purchaseDate, String notes) {
         setIfPresent(item, location, manufacturer,
-                modelName, serialNumber);
-        Item saved = itemRepo.save(item);
-        log.info("Created item {}", saved.getName());
-        return saved;
+                modelName, serialNumber, modelNumber,
+                category);
+        item.setModelYear(modelYear);
+        item.setPurchaseDate(purchaseDate);
+        if (notes != null && !notes.isBlank()) {
+            item.setNotes(notes.trim());
+        }
+    }
+
+    private void setAllFields(
+            Item item, String location,
+            String manufacturer, String modelName,
+            String serialNumber, String modelNumber,
+            Integer modelYear, String category,
+            LocalDate purchaseDate, String notes) {
+        item.setLocation(trimOrNull(location));
+        item.setManufacturer(trimOrNull(manufacturer));
+        item.setModelName(trimOrNull(modelName));
+        item.setSerialNumber(trimOrNull(serialNumber));
+        item.setModelNumber(trimOrNull(modelNumber));
+        item.setCategory(trimOrNull(category));
+        item.setModelYear(modelYear);
+        item.setPurchaseDate(purchaseDate);
+        item.setNotes(trimOrNull(notes));
     }
 
     private void setIfPresent(
             Item item, String location,
             String manufacturer, String modelName,
-            String serialNumber) {
+            String serialNumber, String modelNumber,
+            String category) {
         if (location != null && !location.isBlank()) {
             item.setLocation(location.trim());
         }
@@ -82,5 +176,19 @@ public class ItemManagementService
                 && !serialNumber.isBlank()) {
             item.setSerialNumber(serialNumber.trim());
         }
+        if (modelNumber != null
+                && !modelNumber.isBlank()) {
+            item.setModelNumber(modelNumber.trim());
+        }
+        if (category != null && !category.isBlank()) {
+            item.setCategory(category.trim());
+        }
+    }
+
+    private String trimOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
     }
 }

--- a/src/main/resources/db/migration/V12__require_cost_on_service_records.sql
+++ b/src/main/resources/db/migration/V12__require_cost_on_service_records.sql
@@ -1,0 +1,5 @@
+-- Make cost required on service_records, defaulting existing NULLs to 0.
+UPDATE service_records SET cost = 0 WHERE cost IS NULL;
+ALTER TABLE service_records
+    ALTER COLUMN cost SET DEFAULT 0,
+    ALTER COLUMN cost SET NOT NULL;

--- a/src/main/resources/db/migration/V13__add_category_to_items.sql
+++ b/src/main/resources/db/migration/V13__add_category_to_items.sql
@@ -1,0 +1,1 @@
+ALTER TABLE items ADD COLUMN category VARCHAR(100);

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -26,6 +26,15 @@
                 </a>
             </form>
         </section>
+        <datalist id="category-suggestions">
+            <option value="HVAC"/>
+            <option value="Plumbing"/>
+            <option value="Electrical"/>
+            <option value="Appliance"/>
+            <option value="Roofing"/>
+            <option value="Landscaping"/>
+            <option value="General"/>
+        </datalist>
         <section id="item-list">
             <div class="section-header">
                 <h2>Items</h2>
@@ -42,12 +51,22 @@
                                        placeholder="Item name"/></label>
                     <label>Location <input type="text" name="location"
                                            placeholder="Location"/></label>
+                    <label>Category <input type="text" name="category"
+                                           placeholder="Category" list="category-suggestions"/></label>
                     <label>Manufacturer <input type="text" name="manufacturer"
                                                placeholder="Manufacturer"/></label>
                     <label>Model <input type="text" name="modelName"
                                         placeholder="Model name"/></label>
+                    <label>Model # <input type="text" name="modelNumber"
+                                          placeholder="Model number"/></label>
+                    <label>Year <input type="number" name="modelYear"
+                                       placeholder="Year" min="1900" max="2100"
+                                       style="width:5rem"/></label>
                     <label>Serial # <input type="text" name="serialNumber"
                                            placeholder="Serial number"/></label>
+                    <label>Purchased <input type="date" name="purchaseDate"/></label>
+                    <label>Notes <input type="text" name="notes"
+                                        placeholder="Notes"/></label>
                     <button type="submit" class="btn-icon btn-add">
                         <svg th:replace="~{fragments/icons :: icon-save}"></svg>
                         Save
@@ -64,6 +83,7 @@
                 <tr>
                     <th>Name</th>
                     <th>Location</th>
+                    <th>Category</th>
                     <th>Manufacturer</th>
                     <th>Model</th>
                     <th>Serial #</th>
@@ -77,10 +97,15 @@
                     th:data-navigate="@{/items/{id}(id=${item.id})}">
                     <td th:text="${item.name}"></td>
                     <td th:text="${item.location}"></td>
+                    <td th:text="${item.category}"></td>
                     <td th:text="${item.manufacturer}"></td>
                     <td th:text="${item.modelName}"></td>
                     <td th:text="${item.serialNumber}"></td>
                     <td class="actions">
+                        <button type="button" class="btn-icon btn-edit" title="Edit item"
+                                th:data-target="'edit-item-' + ${item.id}">
+                            <svg th:replace="~{fragments/icons :: icon-pencil}"></svg>
+                        </button>
                         <button type="button" class="btn-icon btn-log" title="One-off service"
                                 th:data-target="'item-oneoff-' + ${item.id}">
                             <svg th:replace="~{fragments/icons :: icon-wrench}"></svg>
@@ -91,8 +116,46 @@
                         </button>
                     </td>
                 </tr>
+                <tr th:id="'edit-item-' + ${item.id}" class="form-row" style="display:none">
+                    <td colspan="7">
+                        <form th:action="@{/items/{id}(id=${item.id})}" method="post" class="inline-form">
+                            <input type="hidden" name="_method" value="PUT"/>
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                            <label>Name <input type="text" name="name" required
+                                               th:value="${item.name}" maxlength="200"/></label>
+                            <label>Location <input type="text" name="location"
+                                                   th:value="${item.location}" maxlength="200"/></label>
+                            <label>Category <input type="text" name="category"
+                                                   th:value="${item.category}" maxlength="100"
+                                                   list="category-suggestions"/></label>
+                            <label>Manufacturer <input type="text" name="manufacturer"
+                                                       th:value="${item.manufacturer}" maxlength="200"/></label>
+                            <label>Model <input type="text" name="modelName"
+                                                th:value="${item.modelName}" maxlength="200"/></label>
+                            <label>Model # <input type="text" name="modelNumber"
+                                                  th:value="${item.modelNumber}" maxlength="200"/></label>
+                            <label>Year <input type="number" name="modelYear"
+                                               th:value="${item.modelYear}" min="1900" max="2100"
+                                               style="width:5rem"/></label>
+                            <label>Serial # <input type="text" name="serialNumber"
+                                                   th:value="${item.serialNumber}" maxlength="200"/></label>
+                            <label>Purchased <input type="date" name="purchaseDate"
+                                                    th:value="${item.purchaseDate}"/></label>
+                            <label>Notes <input type="text" name="notes"
+                                                th:value="${item.notes}"/></label>
+                            <button type="submit" class="btn-icon btn-add">
+                                <svg th:replace="~{fragments/icons :: icon-save}"></svg>
+                                Save
+                            </button>
+                            <button type="button" class="btn-icon btn-cancel" title="Cancel"
+                                    th:data-toggle-form="'edit-item-' + ${item.id}">
+                                <svg th:replace="~{fragments/icons :: icon-cancel}"></svg>
+                            </button>
+                        </form>
+                    </td>
+                </tr>
                 <tr th:id="'item-oneoff-' + ${item.id}" class="form-row" style="display:none">
-                    <td colspan="6">
+                    <td colspan="7">
                         <form method="post" th:action="@{/items/{id}/service-records(id=${item.id})}" class="inline-form">
                             <input type="hidden" name="oneOff" value="true"/>
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
@@ -114,7 +177,7 @@
                     </td>
                 </tr>
                 <tr th:id="'item-sched-' + ${item.id}" class="form-row" style="display:none">
-                    <td colspan="6">
+                    <td colspan="7">
                         <form method="post" th:action="@{/items/{id}/schedules(id=${item.id})}" class="inline-form">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                             <label>Type <input type="text"
@@ -144,7 +207,7 @@
                 </tr>
                 <tr th:if="${selectedItemId != null and selectedItemId.equals(item.id)}"
                     class="detail-row">
-                    <td colspan="6">
+                    <td colspan="7">
                         <div class="item-detail">
                             <div class="detail-section"
                                  th:if="${itemRecords != null and !#lists.isEmpty(itemRecords)}">

--- a/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
@@ -26,6 +26,8 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet
+        .request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
@@ -755,6 +757,109 @@ class ItemControllerIntegrationTest {
         assertTrue(html.contains(
                 "data-toggle-form=\"add-item-form\""),
                 "should have cancel for add form");
+    }
+
+    @Test
+    @DisplayName("should update an existing item")
+    void shouldUpdateItem() throws Exception {
+        String itemId = getFirstItemId();
+        mockMvc.perform(put("/items/" + itemId)
+                        .param("name", "Updated Widget")
+                        .param("location", "Kitchen")
+                        .param("category", "Appliance")
+                        .param("modelNumber", "MN-42")
+                        .param("modelYear", "2025")
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/items"));
+    }
+
+    @Test
+    @DisplayName("should reject blank name on update")
+    void shouldRejectBlankNameOnUpdate()
+            throws Exception {
+        String itemId = getFirstItemId();
+        mockMvc.perform(put("/items/" + itemId)
+                        .param("name", "  ")
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(model().attributeExists(
+                        "error"));
+    }
+
+    @Test
+    @DisplayName("should handle invalid item on update")
+    void shouldHandleInvalidItemOnUpdate()
+            throws Exception {
+        UUID fakeId = UUID.randomUUID();
+        mockMvc.perform(put("/items/" + fakeId)
+                        .param("name", "Test")
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(model().attributeExists(
+                        "error"));
+    }
+
+    @Test
+    @DisplayName("should render edit button for items")
+    void shouldRenderEditButtonForItems()
+            throws Exception {
+        mockMvc.perform(get("/items")
+                        .with(user("dev").roles("USER")))
+                .andExpect(status().isOk())
+                .andExpect(content().string(
+                        containsString(
+                                "data-target=\"edit-item-")));
+    }
+
+    @Test
+    @DisplayName("should render category column")
+    void shouldRenderCategoryColumn()
+            throws Exception {
+        mockMvc.perform(get("/items")
+                        .with(user("dev").roles("USER")))
+                .andExpect(status().isOk())
+                .andExpect(content().string(
+                        containsString(
+                                "<th>Category</th>")));
+    }
+
+    @Test
+    @DisplayName("should render category datalist")
+    void shouldRenderCategoryDatalist()
+            throws Exception {
+        mockMvc.perform(get("/items")
+                        .with(user("dev").roles("USER")))
+                .andExpect(status().isOk())
+                .andExpect(content().string(
+                        containsString(
+                                "id=\"category-suggestions"
+                        )));
+    }
+
+    @Test
+    @DisplayName("should create item with all fields")
+    void shouldCreateItemWithAllFields()
+            throws Exception {
+        mockMvc.perform(post("/items")
+                        .param("name", "Full Item")
+                        .param("location", "Basement")
+                        .param("manufacturer", "Acme")
+                        .param("modelName", "Z-100")
+                        .param("modelNumber", "MN-100")
+                        .param("modelYear", "2024")
+                        .param("serialNumber", "SN-001")
+                        .param("category", "Plumbing")
+                        .param("purchaseDate",
+                                "2024-06-15")
+                        .param("notes", "Test notes")
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/items"));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/solutions/mystuff/domain/model/ServiceRecordTest.java
+++ b/src/test/java/solutions/mystuff/domain/model/ServiceRecordTest.java
@@ -27,7 +27,7 @@ class ServiceRecordTest {
         assertNull(r.getServiceDate());
         assertNull(r.getSummary());
         assertNull(r.getDescription());
-        assertNull(r.getCost());
+        assertEquals(BigDecimal.ZERO, r.getCost());
     }
 
     @Test

--- a/src/test/java/solutions/mystuff/domain/service/ItemManagementServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ItemManagementServiceTest.java
@@ -1,8 +1,11 @@
 package solutions.mystuff.domain.service;
 
+import java.time.LocalDate;
+import java.util.Optional;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.NotFoundException;
 import solutions.mystuff.domain.model.UuidV7;
 import solutions.mystuff.domain.port.out.ItemRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -32,7 +35,9 @@ class ItemManagementServiceTest {
         when(itemRepo.save(any(Item.class)))
                 .thenAnswer(i -> i.getArgument(0));
         Item item = service.createItem(
-                orgId, "Furnace", null, null, null, null);
+                orgId, "Furnace", null, null,
+                null, null, null, null,
+                null, null, null);
         assertEquals("Furnace", item.getName());
         assertEquals(orgId, item.getOrganizationId());
         verify(itemRepo).save(any(Item.class));
@@ -45,7 +50,8 @@ class ItemManagementServiceTest {
                 .thenAnswer(i -> i.getArgument(0));
         Item item = service.createItem(
                 orgId, "  Furnace  ", null,
-                null, null, null);
+                null, null, null, null,
+                null, null, null, null);
         assertEquals("Furnace", item.getName());
     }
 
@@ -55,11 +61,19 @@ class ItemManagementServiceTest {
         when(itemRepo.save(any(Item.class)))
                 .thenAnswer(i -> i.getArgument(0));
         Item item = service.createItem(orgId, "AC",
-                "Roof", "Trane", "XR15", "SN-123");
+                "Roof", "Trane", "XR15", "SN-123",
+                "MN-456", 2024, "HVAC",
+                LocalDate.of(2024, 1, 15), "Good unit");
         assertEquals("Roof", item.getLocation());
         assertEquals("Trane", item.getManufacturer());
         assertEquals("XR15", item.getModelName());
         assertEquals("SN-123", item.getSerialNumber());
+        assertEquals("MN-456", item.getModelNumber());
+        assertEquals(2024, item.getModelYear());
+        assertEquals("HVAC", item.getCategory());
+        assertEquals(LocalDate.of(2024, 1, 15),
+                item.getPurchaseDate());
+        assertEquals("Good unit", item.getNotes());
     }
 
     @Test
@@ -68,7 +82,8 @@ class ItemManagementServiceTest {
         when(itemRepo.save(any(Item.class)))
                 .thenAnswer(i -> i.getArgument(0));
         Item item = service.createItem(
-                orgId, "AC", "  ", "", null, null);
+                orgId, "AC", "  ", "", null,
+                null, null, null, null, null, null);
         assertNull(item.getLocation());
         assertNull(item.getManufacturer());
     }
@@ -79,7 +94,8 @@ class ItemManagementServiceTest {
         assertThrows(IllegalArgumentException.class,
                 () -> service.createItem(
                         orgId, "  ", null,
-                        null, null, null));
+                        null, null, null, null,
+                        null, null, null, null));
     }
 
     @Test
@@ -88,7 +104,8 @@ class ItemManagementServiceTest {
         assertThrows(IllegalArgumentException.class,
                 () -> service.createItem(
                         orgId, null, null,
-                        null, null, null));
+                        null, null, null, null,
+                        null, null, null, null));
     }
 
     @Test
@@ -98,17 +115,81 @@ class ItemManagementServiceTest {
         assertThrows(IllegalArgumentException.class,
                 () -> service.createItem(
                         orgId, longName, null,
-                        null, null, null));
+                        null, null, null, null,
+                        null, null, null, null));
     }
 
     @Test
-    @DisplayName("should reject location exceeding max length")
+    @DisplayName("should reject location exceeding max"
+            + " length")
     void shouldRejectLongLocation() {
         String longLoc = "x".repeat(201);
         assertThrows(IllegalArgumentException.class,
                 () -> service.createItem(
                         orgId, "AC", longLoc,
-                        null, null, null));
+                        null, null, null, null,
+                        null, null, null, null));
     }
 
+    @Test
+    @DisplayName("should update existing item")
+    void shouldUpdateItem() {
+        UUID itemId = UuidV7.generate();
+        Item existing = new Item();
+        existing.setOrganizationId(orgId);
+        existing.setName("Old Name");
+        when(itemRepo.findByIdAndOrganizationId(
+                itemId, orgId))
+                .thenReturn(Optional.of(existing));
+        when(itemRepo.save(any(Item.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        Item updated = service.updateItem(
+                orgId, itemId, "New Name", "Basement",
+                "Trane", "XR15", "MN-100", 2025,
+                "SN-999", LocalDate.of(2025, 6, 1),
+                "HVAC", "Updated notes");
+        assertEquals("New Name", updated.getName());
+        assertEquals("Basement", updated.getLocation());
+        assertEquals("HVAC", updated.getCategory());
+        assertEquals("Updated notes", updated.getNotes());
+        verify(itemRepo).save(any(Item.class));
+    }
+
+    @Test
+    @DisplayName("should throw when updating nonexistent"
+            + " item")
+    void shouldThrowWhenUpdatingNonexistentItem() {
+        UUID itemId = UuidV7.generate();
+        when(itemRepo.findByIdAndOrganizationId(
+                itemId, orgId))
+                .thenReturn(Optional.empty());
+        assertThrows(NotFoundException.class,
+                () -> service.updateItem(
+                        orgId, itemId, "Name", null,
+                        null, null, null, null,
+                        null, null, null, null));
+    }
+
+    @Test
+    @DisplayName("should clear fields on update when"
+            + " blank")
+    void shouldClearFieldsWhenBlank() {
+        UUID itemId = UuidV7.generate();
+        Item existing = new Item();
+        existing.setOrganizationId(orgId);
+        existing.setName("AC");
+        existing.setLocation("Roof");
+        existing.setCategory("HVAC");
+        when(itemRepo.findByIdAndOrganizationId(
+                itemId, orgId))
+                .thenReturn(Optional.of(existing));
+        when(itemRepo.save(any(Item.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        Item updated = service.updateItem(
+                orgId, itemId, "AC", "", null,
+                null, null, null, null,
+                null, null, null);
+        assertNull(updated.getLocation());
+        assertNull(updated.getCategory());
+    }
 }


### PR DESCRIPTION
Add PUT /items/{id} endpoint for editing items with all fields (name, location, manufacturer, model name/number/year, serial number, purchase date, notes, category). Update createItem to accept the same expanded field set. Add inline edit form with pencil icon on each item row. Add category column with datalist suggestions (HVAC, Plumbing, Electrical, Appliance, Roofing, Landscaping, General). Include V13 Flyway migration for the category column and V12 for cost NOT NULL compatibility.