### PR TITLE
Fix dead code, consistency, and quality issues

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/DashboardController.java
+++ b/src/main/java/solutions/mystuff/application/web/DashboardController.java
@@ -2,7 +2,6 @@ package solutions.mystuff.application.web;
 
 import java.security.Principal;
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.AppUser;
@@ -38,7 +37,7 @@ import org.springframework.web.bind.annotation.GetMapping;
         description = "Dashboard home page")
 public class DashboardController {
 
-    private static final Logger LOG =
+    private static final Logger log =
             LoggerFactory.getLogger(
                     DashboardController.class);
     private static final int RECENT_LIMIT = 5;
@@ -74,21 +73,12 @@ public class DashboardController {
             Principal principal, Model model) {
         AppUser user = helper.resolveUser(principal);
         if (!user.hasOrganization()) {
-            return handleNoOrg(user, model);
+            return helper.handleNoOrg(
+                    user, model, "dashboard");
         }
         helper.setOrgMdc(user);
         helper.addUserAttrs(user, model);
         addDashboardAttrs(user, model);
-        return "dashboard";
-    }
-
-    private String handleNoOrg(
-            AppUser user, Model model) {
-        LOG.warn("User {} has no organization",
-                user.getUsername());
-        model.addAttribute("noOrganization", true);
-        model.addAttribute("recentRecords",
-                Collections.emptyList());
         return "dashboard";
     }
 
@@ -98,7 +88,7 @@ public class DashboardController {
         LocalDate today = LocalDate.now();
         LocalDate soonCutoff = today.plusDays(
                 DUE_SOON_DAYS);
-        LOG.info("Loading dashboard for org {}",
+        log.info("Loading dashboard for org {}",
                 orgId);
         model.addAttribute("overdueCount",
                 dashboardQuery.countOverdueSchedules(

--- a/src/main/java/solutions/mystuff/application/web/ItemController.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemController.java
@@ -44,7 +44,7 @@ import org.springframework.web.bind.annotation
         description = "Item CRUD and service operations")
 public class ItemController {
 
-    private static final Logger LOG =
+    private static final Logger log =
             LoggerFactory.getLogger(ItemController.class);
 
     private final ControllerHelper helper;
@@ -285,8 +285,8 @@ public class ItemController {
         LocalDate pd = parseOptionalDate(purchaseDate);
         itemService.updateItem(orgId, itemId, name,
                 location, manufacturer, modelName,
-                modelNumber, modelYear, serialNumber,
-                pd, category, notes);
+                serialNumber, modelNumber, modelYear,
+                category, pd, notes);
         return "redirect:/items";
     }
 
@@ -467,13 +467,13 @@ public class ItemController {
         int safePage = Math.max(0, page);
         PageResult<Item> result;
         if (q != null && !q.isBlank()) {
-            LOG.info("Searching items query={}",
+            log.info("Searching items query={}",
                     LogSanitizer.sanitize(q));
             result = itemQuery.searchByOrganization(
                     orgId, q, safePage, safeSize);
             model.addAttribute("q", q);
         } else {
-            LOG.info("Listing items page={}", safePage);
+            log.info("Listing items page={}", safePage);
             result = itemQuery.findByOrganization(
                     orgId, safePage, safeSize);
         }

--- a/src/main/java/solutions/mystuff/application/web/ItemHistoryPdf.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemHistoryPdf.java
@@ -210,6 +210,8 @@ final class ItemHistoryPdf {
                 || cost.compareTo(BigDecimal.ZERO) == 0) {
             return "";
         }
-        return "$" + cost.setScale(2).toPlainString();
+        return "$" + cost.setScale(2,
+                java.math.RoundingMode.HALF_UP)
+                .toPlainString();
     }
 }

--- a/src/main/java/solutions/mystuff/application/web/ReportController.java
+++ b/src/main/java/solutions/mystuff/application/web/ReportController.java
@@ -11,6 +11,7 @@ import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.NotFoundException;
 import solutions.mystuff.domain.model.ServiceRecord;
 import solutions.mystuff.domain.model.ServiceSchedule;
+import solutions.mystuff.domain.port.in.CostQuery;
 import solutions.mystuff.domain.port.in.ItemQuery;
 import solutions.mystuff.domain.port.in.ScheduleQuery;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,15 +50,13 @@ public class ReportController {
     private final ItemQuery itemQuery;
     private final ScheduleQuery scheduleQuery;
     private final ControllerHelper helper;
-    private final solutions.mystuff.domain.port.in
-            .CostQuery costQuery;
+    private final CostQuery costQuery;
 
     public ReportController(
             ItemQuery itemQuery,
             ScheduleQuery scheduleQuery,
             ControllerHelper helper,
-            solutions.mystuff.domain.port.in
-                    .CostQuery costQuery) {
+            CostQuery costQuery) {
         this.itemQuery = itemQuery;
         this.scheduleQuery = scheduleQuery;
         this.helper = helper;

--- a/src/main/java/solutions/mystuff/domain/port/in/ItemManagement.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/ItemManagement.java
@@ -33,8 +33,8 @@ public interface ItemManagement {
     Item updateItem(UUID orgId, UUID itemId,
             String name, String location,
             String manufacturer, String modelName,
-            String modelNumber, Integer modelYear,
-            String serialNumber, LocalDate purchaseDate,
-            String category, String notes);
+            String serialNumber, String modelNumber,
+            Integer modelYear, String category,
+            LocalDate purchaseDate, String notes);
 
 }

--- a/src/main/java/solutions/mystuff/domain/service/DashboardQueryService.java
+++ b/src/main/java/solutions/mystuff/domain/service/DashboardQueryService.java
@@ -12,6 +12,8 @@ import solutions.mystuff.domain.port.out
 import solutions.mystuff.domain.port.out
         .ServiceScheduleRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation
+        .Transactional;
 
 /**
  * Aggregates dashboard summary data from multiple repositories.
@@ -26,6 +28,7 @@ import org.springframework.stereotype.Service;
  * @see DashboardQuery
  */
 @Service
+@Transactional(readOnly = true)
 public class DashboardQueryService
         implements DashboardQuery {
 

--- a/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
@@ -36,7 +36,7 @@ import org.springframework.transaction.annotation
 public class ItemManagementService
         implements ItemManagement {
 
-    private static final Logger LOG =
+    private static final Logger log =
             LoggerFactory.getLogger(
                     ItemManagementService.class);
     private static final int MAX_LENGTH = 200;
@@ -65,12 +65,11 @@ public class ItemManagementService
         Item item = new Item();
         item.setOrganizationId(orgId);
         item.setName(trimName);
-        applyOptionalFields(item, location,
-                manufacturer, modelName, serialNumber,
-                modelNumber, modelYear, category,
-                purchaseDate, notes);
+        setAllFields(item, location, manufacturer,
+                modelName, serialNumber, modelNumber,
+                modelYear, category, purchaseDate, notes);
         Item saved = itemRepo.save(item);
-        LOG.info("Created item {}", saved.getName());
+        log.info("Created item {}", saved.getName());
         return saved;
     }
 
@@ -81,9 +80,9 @@ public class ItemManagementService
             UUID orgId, UUID itemId,
             String name, String location,
             String manufacturer, String modelName,
-            String modelNumber, Integer modelYear,
-            String serialNumber, LocalDate purchaseDate,
-            String category, String notes) {
+            String serialNumber, String modelNumber,
+            Integer modelYear, String category,
+            LocalDate purchaseDate, String notes) {
         String trimName = validateFields(name, location,
                 manufacturer, modelName, serialNumber,
                 modelNumber, category);
@@ -96,7 +95,7 @@ public class ItemManagementService
                 modelName, serialNumber, modelNumber,
                 modelYear, category, purchaseDate, notes);
         Item saved = itemRepo.save(item);
-        LOG.info("Updated item {}", saved.getName());
+        log.info("Updated item {}", saved.getName());
         return saved;
     }
 
@@ -124,22 +123,6 @@ public class ItemManagementService
         return trimName;
     }
 
-    private void applyOptionalFields(
-            Item item, String location,
-            String manufacturer, String modelName,
-            String serialNumber, String modelNumber,
-            Integer modelYear, String category,
-            LocalDate purchaseDate, String notes) {
-        setIfPresent(item, location, manufacturer,
-                modelName, serialNumber, modelNumber,
-                category);
-        item.setModelYear(modelYear);
-        item.setPurchaseDate(purchaseDate);
-        if (notes != null && !notes.isBlank()) {
-            item.setNotes(notes.trim());
-        }
-    }
-
     private void setAllFields(
             Item item, String location,
             String manufacturer, String modelName,
@@ -155,34 +138,6 @@ public class ItemManagementService
         item.setModelYear(modelYear);
         item.setPurchaseDate(purchaseDate);
         item.setNotes(trimOrNull(notes));
-    }
-
-    private void setIfPresent(
-            Item item, String location,
-            String manufacturer, String modelName,
-            String serialNumber, String modelNumber,
-            String category) {
-        if (location != null && !location.isBlank()) {
-            item.setLocation(location.trim());
-        }
-        if (manufacturer != null
-                && !manufacturer.isBlank()) {
-            item.setManufacturer(manufacturer.trim());
-        }
-        if (modelName != null && !modelName.isBlank()) {
-            item.setModelName(modelName.trim());
-        }
-        if (serialNumber != null
-                && !serialNumber.isBlank()) {
-            item.setSerialNumber(serialNumber.trim());
-        }
-        if (modelNumber != null
-                && !modelNumber.isBlank()) {
-            item.setModelNumber(modelNumber.trim());
-        }
-        if (category != null && !category.isBlank()) {
-            item.setCategory(category.trim());
-        }
     }
 
     private String trimOrNull(String value) {

--- a/src/main/resources/templates/reports.html
+++ b/src/main/resources/templates/reports.html
@@ -62,15 +62,15 @@
                 </tbody>
             </table>
         </section>
-        <section id="cost-summary" th:if="${costTrackingEnabled}">
+        <section id="cost-summary">
             <h2>Cost Summary</h2>
             <div class="cost-totals">
                 <p><strong th:text="${currentYear}"></strong> spend:
-                    <strong th:text="'$' + #numbers.formatDecimal(totalSpendThisYear, 1, 2)"></strong></p>
+                    <strong th:text="|$${#numbers.formatDecimal(totalSpendThisYear, 1, 2)}|"></strong></p>
                 <p>All-time spend:
-                    <strong th:text="'$' + #numbers.formatDecimal(totalSpendAllTime, 1, 2)"></strong></p>
+                    <strong th:text="|$${#numbers.formatDecimal(totalSpendAllTime, 1, 2)}|"></strong></p>
             </div>
-            <div th:if="${!#lists.isEmpty(topItemsByCost)}">
+            <div th:if="${not #lists.isEmpty(topItemsByCost)}">
                 <h3>Top Items by Cost</h3>
                 <table>
                     <thead><tr>
@@ -80,7 +80,7 @@
                     <tbody>
                     <tr th:each="ic : ${topItemsByCost}">
                         <td th:text="${ic.itemName()}"></td>
-                        <td th:text="'$' + #numbers.formatDecimal(ic.totalCost(), 1, 2)"></td>
+                        <td th:text="|$${#numbers.formatDecimal(ic.totalCost(), 1, 2)}|"></td>
                     </tr>
                     </tbody>
                 </table>

--- a/src/test/java/solutions/mystuff/domain/service/ItemManagementServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ItemManagementServiceTest.java
@@ -145,9 +145,10 @@ class ItemManagementServiceTest {
                 .thenAnswer(i -> i.getArgument(0));
         Item updated = service.updateItem(
                 orgId, itemId, "New Name", "Basement",
-                "Trane", "XR15", "MN-100", 2025,
-                "SN-999", LocalDate.of(2025, 6, 1),
-                "HVAC", "Updated notes");
+                "Trane", "XR15", "SN-999", "MN-100",
+                2025, "HVAC",
+                LocalDate.of(2025, 6, 1),
+                "Updated notes");
         assertEquals("New Name", updated.getName());
         assertEquals("Basement", updated.getLocation());
         assertEquals("HVAC", updated.getCategory());


### PR DESCRIPTION
## Summary
- Remove `costTrackingEnabled` guard that was never set — cost summary on reports page now actually renders; fix Thymeleaf expression syntax for currency formatting
- Add `@Transactional(readOnly=true)` to `DashboardQueryService` (4 queries were each opening their own transaction)
- Add `RoundingMode.HALF_UP` to `ItemHistoryPdf.formatCost` to prevent `ArithmeticException`
- Replace FQN with import for `CostQuery` in `ReportController`
- Use `ControllerHelper.handleNoOrg` in `DashboardController` instead of duplicating the pattern
- Normalize logger naming to `log` (was `LOG` in 3 files)
- Fix parameter ordering inconsistency between `createItem`/`updateItem` to prevent latent swap bugs
- Remove duplicate `applyOptionalFields`/`setIfPresent` in favor of shared `setAllFields`/`trimOrNull` (-50 lines)

## Test plan
- [x] All 369 tests pass (0 failures, 0 errors)
- [x] Full `mvnw verify` clean (checkstyle, coverage, javadoc)
- [ ] Verify reports page renders cost summary section
- [ ] Verify item edit saves fields correctly with new parameter ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)