### PR TITLE
Replace parameter sprawl with ItemSpec and ServiceCompletion records

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/ItemController.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemController.java
@@ -8,9 +8,11 @@ import java.util.UUID;
 import solutions.mystuff.domain.model.AppUser;
 import solutions.mystuff.domain.model.FrequencyUnit;
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.ItemSpec;
 import solutions.mystuff.domain.model.LogSanitizer;
 import solutions.mystuff.domain.model.NotFoundException;
 import solutions.mystuff.domain.model.PageResult;
+import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.Vendor;
 import solutions.mystuff.domain.port.in.ItemManagement;
 import solutions.mystuff.domain.port.in.ItemQuery;
@@ -217,10 +219,11 @@ public class ItemController {
         helper.setOrgMdc(user);
         UUID orgId = user.getOrganization().getId();
         LocalDate pd = parseOptionalDate(purchaseDate);
-        itemService.createItem(orgId, name,
-                location, manufacturer, modelName,
-                serialNumber, modelNumber, modelYear,
-                category, pd, notes);
+        ItemSpec spec = new ItemSpec(name, location,
+                manufacturer, modelName, serialNumber,
+                modelNumber, modelYear, category,
+                pd, notes);
+        itemService.createItem(orgId, spec);
         return "redirect:/items";
     }
 
@@ -283,10 +286,11 @@ public class ItemController {
         helper.setOrgMdc(user);
         UUID orgId = user.getOrganization().getId();
         LocalDate pd = parseOptionalDate(purchaseDate);
-        itemService.updateItem(orgId, itemId, name,
-                location, manufacturer, modelName,
-                serialNumber, modelNumber, modelYear,
-                category, pd, notes);
+        ItemSpec spec = new ItemSpec(name, location,
+                manufacturer, modelName, serialNumber,
+                modelNumber, modelYear, category,
+                pd, notes);
+        itemService.updateItem(orgId, itemId, spec);
         return "redirect:/items";
     }
 
@@ -359,14 +363,15 @@ public class ItemController {
                 newVendorPhone);
         LocalDate date = InputValidator.parseDate(
                 serviceDate, "Service date");
+        ServiceCompletion completion =
+                new ServiceCompletion(vendor, summary,
+                        date, techName, cost);
         if (oneOff) {
-            recordService.createRecord(orgId, item,
-                    null, null, vendor, summary,
-                    date, techName, cost);
+            recordService.createRecord(
+                    orgId, item, null, completion);
         } else {
             scheduleService.completeNextForItem(
-                    orgId, itemId, vendor,
-                    summary, date, techName, cost);
+                    orgId, itemId, completion);
         }
         return "redirect:/items";
     }

--- a/src/main/java/solutions/mystuff/application/web/ScheduleController.java
+++ b/src/main/java/solutions/mystuff/application/web/ScheduleController.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import solutions.mystuff.domain.model.AppUser;
 import solutions.mystuff.domain.model.FrequencyUnit;
 import solutions.mystuff.domain.model.PageResult;
+import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.ServiceSchedule;
 import solutions.mystuff.domain.model.Vendor;
 import solutions.mystuff.domain.port.in.ScheduleLifecycle;
@@ -167,10 +168,12 @@ public class ScheduleController {
                 newVendorPhone);
         LocalDate date = InputValidator.parseDate(
                 serviceDate, "Service date");
+        ServiceCompletion completion =
+                new ServiceCompletion(vendor, summary,
+                        date, techName, cost);
         ServiceSchedule sched =
                 scheduleService.completeSchedule(
-                        scheduleId, orgId, vendor,
-                        summary, date, techName, cost);
+                        scheduleId, orgId, completion);
         if ("item".equals(redirectTo)) {
             return "redirect:/items/"
                     + sched.getItem().getId();

--- a/src/main/java/solutions/mystuff/domain/model/ItemSpec.java
+++ b/src/main/java/solutions/mystuff/domain/model/ItemSpec.java
@@ -1,0 +1,40 @@
+package solutions.mystuff.domain.model;
+
+import java.time.LocalDate;
+
+/**
+ * Value object carrying the mutable fields of an {@link Item}.
+ * Used as a parameter object for create and update operations.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class ItemSpec {
+ *         String name
+ *         String location
+ *         String manufacturer
+ *         String modelName
+ *         String serialNumber
+ *         String modelNumber
+ *         Integer modelYear
+ *         String category
+ *         LocalDate purchaseDate
+ *         String notes
+ *     }
+ *     ItemManagement ..&gt; ItemSpec : uses
+ *     Item ..&gt; ItemSpec : populated from
+ * </div>
+ *
+ * @see Item
+ */
+public record ItemSpec(
+        String name,
+        String location,
+        String manufacturer,
+        String modelName,
+        String serialNumber,
+        String modelNumber,
+        Integer modelYear,
+        String category,
+        LocalDate purchaseDate,
+        String notes) {
+}

--- a/src/main/java/solutions/mystuff/domain/model/ServiceCompletion.java
+++ b/src/main/java/solutions/mystuff/domain/model/ServiceCompletion.java
@@ -1,0 +1,31 @@
+package solutions.mystuff.domain.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Value object carrying the details of a service visit.
+ * Groups vendor, summary, date, technician, and cost.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class ServiceCompletion {
+ *         Vendor vendor
+ *         String summary
+ *         LocalDate serviceDate
+ *         String techName
+ *         BigDecimal cost
+ *     }
+ *     ScheduleLifecycle ..&gt; ServiceCompletion : uses
+ *     RecordCreation ..&gt; ServiceCompletion : uses
+ * </div>
+ *
+ * @see ServiceRecord
+ */
+public record ServiceCompletion(
+        Vendor vendor,
+        String summary,
+        LocalDate serviceDate,
+        String techName,
+        BigDecimal cost) {
+}

--- a/src/main/java/solutions/mystuff/domain/port/in/ItemManagement.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/ItemManagement.java
@@ -1,9 +1,9 @@
 package solutions.mystuff.domain.port.in;
 
-import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.ItemSpec;
 
 /**
  * Inbound port for creating and managing items.
@@ -11,8 +11,8 @@ import solutions.mystuff.domain.model.Item;
  * <div class="mermaid">
  * classDiagram
  *     class ItemManagement {
- *         +createItem(UUID, String, String, String, String, String, String, Integer, String, LocalDate, String) Item
- *         +updateItem(UUID, UUID, String, String, String, String, String, Integer, String, LocalDate, String, String) Item
+ *         +createItem(UUID, ItemSpec) Item
+ *         +updateItem(UUID, UUID, ItemSpec) Item
  *     }
  *     ItemManagementService ..|> ItemManagement
  * </div>
@@ -22,19 +22,10 @@ import solutions.mystuff.domain.model.Item;
 public interface ItemManagement {
 
     /** Validate inputs and create a new item for the organization. */
-    Item createItem(UUID orgId, String name,
-            String location, String manufacturer,
-            String modelName, String serialNumber,
-            String modelNumber, Integer modelYear,
-            String category, LocalDate purchaseDate,
-            String notes);
+    Item createItem(UUID orgId, ItemSpec spec);
 
     /** Validate inputs and update an existing item. */
     Item updateItem(UUID orgId, UUID itemId,
-            String name, String location,
-            String manufacturer, String modelName,
-            String serialNumber, String modelNumber,
-            Integer modelYear, String category,
-            LocalDate purchaseDate, String notes);
+            ItemSpec spec);
 
 }

--- a/src/main/java/solutions/mystuff/domain/port/in/RecordCreation.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/RecordCreation.java
@@ -1,12 +1,10 @@
 package solutions.mystuff.domain.port.in;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.ServiceSchedule;
-import solutions.mystuff.domain.model.Vendor;
 
 /**
  * Inbound port for creating service records.
@@ -14,7 +12,7 @@ import solutions.mystuff.domain.model.Vendor;
  * <div class="mermaid">
  * classDiagram
  *     class RecordCreation {
- *         +createRecord(UUID, Item, String, ServiceSchedule, Vendor, String, LocalDate, String, BigDecimal) void
+ *         +createRecord(UUID, Item, ServiceSchedule, ServiceCompletion) void
  *     }
  *     RecordCreationService ..|> RecordCreation
  * </div>
@@ -26,13 +24,15 @@ public interface RecordCreation {
     /**
      * Create a new service record (visit) for the given item.
      *
+     * <p>When a schedule is provided, the service type is
+     * extracted from it. For one-off records (no schedule),
+     * the service type is null.
+     *
      * <p>Vendor and techName are optional but encouraged for
      * traceability. Unlike schedules, visits do not require
      * a vendor.
      */
     void createRecord(UUID orgId, Item item,
-            String serviceType,
-            ServiceSchedule schedule, Vendor vendor,
-            String summary, LocalDate serviceDate,
-            String techName, BigDecimal cost);
+            ServiceSchedule schedule,
+            ServiceCompletion completion);
 }

--- a/src/main/java/solutions/mystuff/domain/port/in/ScheduleLifecycle.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/ScheduleLifecycle.java
@@ -1,10 +1,10 @@
 package solutions.mystuff.domain.port.in;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.FrequencyUnit;
+import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.ServiceSchedule;
 import solutions.mystuff.domain.model.Vendor;
 
@@ -15,10 +15,11 @@ import solutions.mystuff.domain.model.Vendor;
  * classDiagram
  *     class ScheduleLifecycle {
  *         +createSchedule(UUID, UUID, String, Vendor, LocalDate, int, FrequencyUnit) ServiceSchedule
- *         +completeSchedule(UUID, UUID, Vendor, String, LocalDate, String, BigDecimal) ServiceSchedule
+ *         +completeSchedule(UUID, UUID, ServiceCompletion) ServiceSchedule
  *         +skipSchedule(UUID, UUID) ServiceSchedule
  *         +editSchedule(UUID, UUID, String, LocalDate, int, FrequencyUnit, Vendor) ServiceSchedule
  *         +deactivateSchedule(UUID, UUID) void
+ *         +completeNextForItem(UUID, UUID, ServiceCompletion) void
  *     }
  *     ScheduleLifecycleService ..|> ScheduleLifecycle
  * </div>
@@ -36,9 +37,7 @@ public interface ScheduleLifecycle {
 
     /** Mark a schedule as completed and log the service. */
     ServiceSchedule completeSchedule(UUID scheduleId,
-            UUID orgId, Vendor vendor, String summary,
-            LocalDate serviceDate, String techName,
-            BigDecimal cost);
+            UUID orgId, ServiceCompletion completion);
 
     /** Skip the current occurrence and advance the due date. */
     ServiceSchedule skipSchedule(
@@ -61,7 +60,5 @@ public interface ScheduleLifecycle {
      * or create a one-off record if no active schedule exists.
      */
     void completeNextForItem(UUID orgId, UUID itemId,
-            Vendor vendor, String summary,
-            LocalDate serviceDate, String techName,
-            BigDecimal cost);
+            ServiceCompletion completion);
 }

--- a/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
@@ -1,9 +1,9 @@
 package solutions.mystuff.domain.service;
 
-import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.ItemSpec;
 import solutions.mystuff.domain.model.NotFoundException;
 import solutions.mystuff.domain.model.Validation;
 import solutions.mystuff.domain.port.in.ItemManagement;
@@ -52,22 +52,12 @@ public class ItemManagementService
     /** Validates input lengths and creates a new item. */
     @Override
     @Transactional
-    public Item createItem(
-            UUID orgId, String name,
-            String location, String manufacturer,
-            String modelName, String serialNumber,
-            String modelNumber, Integer modelYear,
-            String category, LocalDate purchaseDate,
-            String notes) {
-        String trimName = validateFields(name, location,
-                manufacturer, modelName, serialNumber,
-                modelNumber, category);
+    public Item createItem(UUID orgId, ItemSpec spec) {
+        String trimName = validateFields(spec);
         Item item = new Item();
         item.setOrganizationId(orgId);
         item.setName(trimName);
-        setAllFields(item, location, manufacturer,
-                modelName, serialNumber, modelNumber,
-                modelYear, category, purchaseDate, notes);
+        setAllFields(item, spec);
         Item saved = itemRepo.save(item);
         log.info("Created item {}", saved.getName());
         return saved;
@@ -77,67 +67,58 @@ public class ItemManagementService
     @Override
     @Transactional
     public Item updateItem(
-            UUID orgId, UUID itemId,
-            String name, String location,
-            String manufacturer, String modelName,
-            String serialNumber, String modelNumber,
-            Integer modelYear, String category,
-            LocalDate purchaseDate, String notes) {
-        String trimName = validateFields(name, location,
-                manufacturer, modelName, serialNumber,
-                modelNumber, category);
+            UUID orgId, UUID itemId, ItemSpec spec) {
+        String trimName = validateFields(spec);
         Item item = itemRepo
                 .findByIdAndOrganizationId(itemId, orgId)
                 .orElseThrow(() -> new NotFoundException(
                         "Item not found"));
         item.setName(trimName);
-        setAllFields(item, location, manufacturer,
-                modelName, serialNumber, modelNumber,
-                modelYear, category, purchaseDate, notes);
+        setAllFields(item, spec);
         Item saved = itemRepo.save(item);
         log.info("Updated item {}", saved.getName());
         return saved;
     }
 
-    private String validateFields(
-            String name, String location,
-            String manufacturer, String modelName,
-            String serialNumber, String modelNumber,
-            String category) {
+    private String validateFields(ItemSpec spec) {
         String trimName = Validation.requireNotBlank(
-                name, "Item name");
+                spec.name(), "Item name");
         Validation.requireMaxLength(
                 trimName, "Item name", MAX_LENGTH);
         Validation.requireMaxLength(
-                location, "Location", MAX_LENGTH);
+                spec.location(), "Location", MAX_LENGTH);
         Validation.requireMaxLength(
-                manufacturer, "Manufacturer", MAX_LENGTH);
+                spec.manufacturer(),
+                "Manufacturer", MAX_LENGTH);
         Validation.requireMaxLength(
-                modelName, "Model name", MAX_LENGTH);
+                spec.modelName(),
+                "Model name", MAX_LENGTH);
         Validation.requireMaxLength(
-                serialNumber, "Serial number", MAX_LENGTH);
+                spec.serialNumber(),
+                "Serial number", MAX_LENGTH);
         Validation.requireMaxLength(
-                modelNumber, "Model number", MAX_LENGTH);
+                spec.modelNumber(),
+                "Model number", MAX_LENGTH);
         Validation.requireMaxLength(
-                category, "Category", CATEGORY_MAX);
+                spec.category(),
+                "Category", CATEGORY_MAX);
         return trimName;
     }
 
     private void setAllFields(
-            Item item, String location,
-            String manufacturer, String modelName,
-            String serialNumber, String modelNumber,
-            Integer modelYear, String category,
-            LocalDate purchaseDate, String notes) {
-        item.setLocation(trimOrNull(location));
-        item.setManufacturer(trimOrNull(manufacturer));
-        item.setModelName(trimOrNull(modelName));
-        item.setSerialNumber(trimOrNull(serialNumber));
-        item.setModelNumber(trimOrNull(modelNumber));
-        item.setCategory(trimOrNull(category));
-        item.setModelYear(modelYear);
-        item.setPurchaseDate(purchaseDate);
-        item.setNotes(trimOrNull(notes));
+            Item item, ItemSpec spec) {
+        item.setLocation(trimOrNull(spec.location()));
+        item.setManufacturer(
+                trimOrNull(spec.manufacturer()));
+        item.setModelName(trimOrNull(spec.modelName()));
+        item.setSerialNumber(
+                trimOrNull(spec.serialNumber()));
+        item.setModelNumber(
+                trimOrNull(spec.modelNumber()));
+        item.setCategory(trimOrNull(spec.category()));
+        item.setModelYear(spec.modelYear());
+        item.setPurchaseDate(spec.purchaseDate());
+        item.setNotes(trimOrNull(spec.notes()));
     }
 
     private String trimOrNull(String value) {

--- a/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
+++ b/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
@@ -1,13 +1,12 @@
 package solutions.mystuff.domain.service;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.ServiceRecord;
 import solutions.mystuff.domain.model.ServiceSchedule;
-import solutions.mystuff.domain.model.Vendor;
 import solutions.mystuff.domain.port.in.RecordCreation;
 import solutions.mystuff.domain.port.out
         .ServiceRecordRepository;
@@ -52,25 +51,27 @@ public class RecordCreationService
     @Override
     public void createRecord(
             UUID orgId, Item item,
-            String serviceType,
-            ServiceSchedule schedule, Vendor vendor,
-            String summary, LocalDate serviceDate,
-            String techName, BigDecimal cost) {
-        validateSummary(summary);
-        validateTechName(techName);
+            ServiceSchedule schedule,
+            ServiceCompletion completion) {
+        validateSummary(completion.summary());
+        validateTechName(completion.techName());
+        String serviceType = schedule != null
+                ? schedule.getServiceType() : null;
         ServiceRecord record = new ServiceRecord();
         record.setOrganizationId(orgId);
         record.setItem(item);
         record.setServiceType(serviceType);
         record.setServiceSchedule(schedule);
-        record.setVendor(vendor);
-        record.setServiceDate(serviceDate);
-        record.setSummary(summary.trim());
-        if (techName != null && !techName.isBlank()) {
-            record.setTechnicianName(techName.trim());
+        record.setVendor(completion.vendor());
+        record.setServiceDate(completion.serviceDate());
+        record.setSummary(completion.summary().trim());
+        if (completion.techName() != null
+                && !completion.techName().isBlank()) {
+            record.setTechnicianName(
+                    completion.techName().trim());
         }
-        record.setCost(
-                cost != null ? cost : BigDecimal.ZERO);
+        record.setCost(completion.cost() != null
+                ? completion.cost() : BigDecimal.ZERO);
         recordRepo.save(record);
         log.info("Saved service record for item {}",
                 item.getId());

--- a/src/main/java/solutions/mystuff/domain/service/ScheduleLifecycleService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ScheduleLifecycleService.java
@@ -1,6 +1,5 @@
 package solutions.mystuff.domain.service;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
@@ -9,6 +8,7 @@ import java.util.UUID;
 import solutions.mystuff.domain.model.FrequencyUnit;
 import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.NotFoundException;
+import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.ServiceSchedule;
 import solutions.mystuff.domain.model.Vendor;
 import solutions.mystuff.domain.port.in.RecordCreation;
@@ -101,17 +101,13 @@ public class ScheduleLifecycleService
     @Transactional
     public ServiceSchedule completeSchedule(
             UUID scheduleId, UUID orgId,
-            Vendor vendor, String summary,
-            LocalDate serviceDate, String techName,
-            BigDecimal cost) {
+            ServiceCompletion completion) {
         ServiceSchedule sched =
                 findSchedule(scheduleId, orgId);
         recordCreation.createRecord(orgId,
-                sched.getItem(),
-                sched.getServiceType(), sched,
-                vendor, summary, serviceDate,
-                techName, cost);
-        sched.advanceNextDueDate(serviceDate);
+                sched.getItem(), sched, completion);
+        sched.advanceNextDueDate(
+                completion.serviceDate());
         ServiceSchedule saved =
                 scheduleRepo.save(sched);
         log.info("Completed schedule {}", scheduleId);
@@ -178,9 +174,8 @@ public class ScheduleLifecycleService
     @Override
     @Transactional
     public void completeNextForItem(
-            UUID orgId, UUID itemId, Vendor vendor,
-            String summary, LocalDate serviceDate,
-            String techName, BigDecimal cost) {
+            UUID orgId, UUID itemId,
+            ServiceCompletion completion) {
         List<ServiceSchedule> schedules =
                 itemQuery.findSchedulesByItem(
                         itemId, orgId);
@@ -192,14 +187,12 @@ public class ScheduleLifecycleService
                                 : LocalDate.MAX))
                 .orElse(null);
         if (next != null) {
-            completeSchedule(next.getId(), orgId,
-                    vendor, summary, serviceDate,
-                    techName, cost);
+            completeSchedule(
+                    next.getId(), orgId, completion);
         } else {
             Item item = findItem(itemId, orgId);
-            recordCreation.createRecord(orgId, item,
-                    null, null, vendor, summary,
-                    serviceDate, techName, cost);
+            recordCreation.createRecord(
+                    orgId, item, null, completion);
         }
     }
 

--- a/src/test/java/solutions/mystuff/domain/service/ItemManagementServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ItemManagementServiceTest.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.ItemSpec;
 import solutions.mystuff.domain.model.NotFoundException;
 import solutions.mystuff.domain.model.UuidV7;
 import solutions.mystuff.domain.port.out.ItemRepository;
@@ -34,10 +35,10 @@ class ItemManagementServiceTest {
     void shouldCreateItem() {
         when(itemRepo.save(any(Item.class)))
                 .thenAnswer(i -> i.getArgument(0));
-        Item item = service.createItem(
-                orgId, "Furnace", null, null,
-                null, null, null, null,
-                null, null, null);
+        ItemSpec spec = new ItemSpec("Furnace",
+                null, null, null, null, null,
+                null, null, null, null);
+        Item item = service.createItem(orgId, spec);
         assertEquals("Furnace", item.getName());
         assertEquals(orgId, item.getOrganizationId());
         verify(itemRepo).save(any(Item.class));
@@ -48,10 +49,10 @@ class ItemManagementServiceTest {
     void shouldTrimName() {
         when(itemRepo.save(any(Item.class)))
                 .thenAnswer(i -> i.getArgument(0));
-        Item item = service.createItem(
-                orgId, "  Furnace  ", null,
-                null, null, null, null,
+        ItemSpec spec = new ItemSpec("  Furnace  ",
+                null, null, null, null, null,
                 null, null, null, null);
+        Item item = service.createItem(orgId, spec);
         assertEquals("Furnace", item.getName());
     }
 
@@ -60,10 +61,11 @@ class ItemManagementServiceTest {
     void shouldSetOptionalFields() {
         when(itemRepo.save(any(Item.class)))
                 .thenAnswer(i -> i.getArgument(0));
-        Item item = service.createItem(orgId, "AC",
-                "Roof", "Trane", "XR15", "SN-123",
-                "MN-456", 2024, "HVAC",
+        ItemSpec spec = new ItemSpec("AC", "Roof",
+                "Trane", "XR15", "SN-123", "MN-456",
+                2024, "HVAC",
                 LocalDate.of(2024, 1, 15), "Good unit");
+        Item item = service.createItem(orgId, spec);
         assertEquals("Roof", item.getLocation());
         assertEquals("Trane", item.getManufacturer());
         assertEquals("XR15", item.getModelName());
@@ -81,9 +83,10 @@ class ItemManagementServiceTest {
     void shouldSkipBlankOptional() {
         when(itemRepo.save(any(Item.class)))
                 .thenAnswer(i -> i.getArgument(0));
-        Item item = service.createItem(
-                orgId, "AC", "  ", "", null,
-                null, null, null, null, null, null);
+        ItemSpec spec = new ItemSpec("AC", "  ", "",
+                null, null, null, null, null,
+                null, null);
+        Item item = service.createItem(orgId, spec);
         assertNull(item.getLocation());
         assertNull(item.getManufacturer());
     }
@@ -91,32 +94,32 @@ class ItemManagementServiceTest {
     @Test
     @DisplayName("should reject blank name")
     void shouldRejectBlankName() {
+        ItemSpec spec = new ItemSpec("  ", null,
+                null, null, null, null, null,
+                null, null, null);
         assertThrows(IllegalArgumentException.class,
-                () -> service.createItem(
-                        orgId, "  ", null,
-                        null, null, null, null,
-                        null, null, null, null));
+                () -> service.createItem(orgId, spec));
     }
 
     @Test
     @DisplayName("should reject null name")
     void shouldRejectNullName() {
+        ItemSpec spec = new ItemSpec(null, null,
+                null, null, null, null, null,
+                null, null, null);
         assertThrows(IllegalArgumentException.class,
-                () -> service.createItem(
-                        orgId, null, null,
-                        null, null, null, null,
-                        null, null, null, null));
+                () -> service.createItem(orgId, spec));
     }
 
     @Test
     @DisplayName("should reject name exceeding max length")
     void shouldRejectLongName() {
         String longName = "x".repeat(201);
+        ItemSpec spec = new ItemSpec(longName, null,
+                null, null, null, null, null,
+                null, null, null);
         assertThrows(IllegalArgumentException.class,
-                () -> service.createItem(
-                        orgId, longName, null,
-                        null, null, null, null,
-                        null, null, null, null));
+                () -> service.createItem(orgId, spec));
     }
 
     @Test
@@ -124,11 +127,11 @@ class ItemManagementServiceTest {
             + " length")
     void shouldRejectLongLocation() {
         String longLoc = "x".repeat(201);
+        ItemSpec spec = new ItemSpec("AC", longLoc,
+                null, null, null, null, null,
+                null, null, null);
         assertThrows(IllegalArgumentException.class,
-                () -> service.createItem(
-                        orgId, "AC", longLoc,
-                        null, null, null, null,
-                        null, null, null, null));
+                () -> service.createItem(orgId, spec));
     }
 
     @Test
@@ -143,12 +146,13 @@ class ItemManagementServiceTest {
                 .thenReturn(Optional.of(existing));
         when(itemRepo.save(any(Item.class)))
                 .thenAnswer(i -> i.getArgument(0));
-        Item updated = service.updateItem(
-                orgId, itemId, "New Name", "Basement",
-                "Trane", "XR15", "SN-999", "MN-100",
-                2025, "HVAC",
+        ItemSpec spec = new ItemSpec("New Name",
+                "Basement", "Trane", "XR15", "SN-999",
+                "MN-100", 2025, "HVAC",
                 LocalDate.of(2025, 6, 1),
                 "Updated notes");
+        Item updated = service.updateItem(
+                orgId, itemId, spec);
         assertEquals("New Name", updated.getName());
         assertEquals("Basement", updated.getLocation());
         assertEquals("HVAC", updated.getCategory());
@@ -164,11 +168,12 @@ class ItemManagementServiceTest {
         when(itemRepo.findByIdAndOrganizationId(
                 itemId, orgId))
                 .thenReturn(Optional.empty());
+        ItemSpec spec = new ItemSpec("Name", null,
+                null, null, null, null, null,
+                null, null, null);
         assertThrows(NotFoundException.class,
                 () -> service.updateItem(
-                        orgId, itemId, "Name", null,
-                        null, null, null, null,
-                        null, null, null, null));
+                        orgId, itemId, spec));
     }
 
     @Test
@@ -186,10 +191,11 @@ class ItemManagementServiceTest {
                 .thenReturn(Optional.of(existing));
         when(itemRepo.save(any(Item.class)))
                 .thenAnswer(i -> i.getArgument(0));
+        ItemSpec spec = new ItemSpec("AC", "", null,
+                null, null, null, null, null,
+                null, null);
         Item updated = service.updateItem(
-                orgId, itemId, "AC", "", null,
-                null, null, null, null,
-                null, null, null);
+                orgId, itemId, spec);
         assertNull(updated.getLocation());
         assertNull(updated.getCategory());
     }

--- a/src/test/java/solutions/mystuff/domain/service/RecordCreationServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/RecordCreationServiceTest.java
@@ -5,7 +5,9 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.ServiceRecord;
+import solutions.mystuff.domain.model.ServiceSchedule;
 import solutions.mystuff.domain.port.out
         .ServiceRecordRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -35,14 +37,19 @@ class RecordCreationServiceTest {
     void shouldCreateRecord() {
         Item item = new Item();
         item.setName("Test Item");
+        ServiceSchedule schedule = new ServiceSchedule();
+        schedule.setServiceType("Filter Change");
         when(repo.save(any(ServiceRecord.class)))
                 .thenAnswer(i -> i.getArgument(0));
 
+        ServiceCompletion completion =
+                new ServiceCompletion(null,
+                        "Replaced filter",
+                        LocalDate.of(2026, 3, 10),
+                        "John",
+                        new BigDecimal("50.00"));
         service.createRecord(orgId, item,
-                "Filter Change", null, null,
-                "Replaced filter",
-                LocalDate.of(2026, 3, 10), "John",
-                new BigDecimal("50.00"));
+                schedule, completion);
 
         ArgumentCaptor<ServiceRecord> captor =
                 ArgumentCaptor.forClass(
@@ -53,6 +60,8 @@ class RecordCreationServiceTest {
                 .isEqualTo("Replaced filter");
         assertThat(saved.getTechnicianName())
                 .isEqualTo("John");
+        assertThat(saved.getServiceType())
+                .isEqualTo("Filter Change");
     }
 
     @Test
@@ -63,9 +72,11 @@ class RecordCreationServiceTest {
         when(repo.save(any(ServiceRecord.class)))
                 .thenAnswer(i -> i.getArgument(0));
 
+        ServiceCompletion completion =
+                new ServiceCompletion(null, "Summary",
+                        LocalDate.now(), "  ", null);
         service.createRecord(orgId, item,
-                "Test", null, null, "Summary",
-                LocalDate.now(), "  ", null);
+                null, completion);
 
         ArgumentCaptor<ServiceRecord> captor =
                 ArgumentCaptor.forClass(
@@ -79,10 +90,12 @@ class RecordCreationServiceTest {
     @DisplayName("should reject blank summary")
     void shouldRejectBlankSummary() {
         Item item = new Item();
+        ServiceCompletion completion =
+                new ServiceCompletion(null, "  ",
+                        LocalDate.now(), null, null);
         assertThatThrownBy(() ->
                 service.createRecord(orgId, item,
-                        "Test", null, null, "  ",
-                        LocalDate.now(), null, null))
+                        null, completion))
                 .isInstanceOf(
                         IllegalArgumentException.class)
                 .hasMessageContaining("required");
@@ -93,11 +106,13 @@ class RecordCreationServiceTest {
     void shouldRejectLongSummary() {
         Item item = new Item();
         String longSummary = "x".repeat(251);
+        ServiceCompletion completion =
+                new ServiceCompletion(null,
+                        longSummary,
+                        LocalDate.now(), null, null);
         assertThatThrownBy(() ->
                 service.createRecord(orgId, item,
-                        "Test", null, null,
-                        longSummary,
-                        LocalDate.now(), null, null))
+                        null, completion))
                 .isInstanceOf(
                         IllegalArgumentException.class)
                 .hasMessageContaining("maximum length");
@@ -108,12 +123,13 @@ class RecordCreationServiceTest {
     void shouldRejectLongTechName() {
         Item item = new Item();
         String longTech = "x".repeat(201);
+        ServiceCompletion completion =
+                new ServiceCompletion(null, "Summary",
+                        LocalDate.now(), longTech,
+                        null);
         assertThatThrownBy(() ->
                 service.createRecord(orgId, item,
-                        "Test", null, null,
-                        "Summary",
-                        LocalDate.now(), longTech,
-                        null))
+                        null, completion))
                 .isInstanceOf(
                         IllegalArgumentException.class)
                 .hasMessageContaining("maximum length");

--- a/src/test/java/solutions/mystuff/domain/service/ScheduleLifecycleServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ScheduleLifecycleServiceTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import solutions.mystuff.domain.model.FrequencyUnit;
 import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.NotFoundException;
+import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.ServiceSchedule;
 import solutions.mystuff.domain.model.Vendor;
 import solutions.mystuff.domain.port.in.ItemQuery;
@@ -112,13 +113,15 @@ class ScheduleLifecycleServiceTest {
                 .thenAnswer(i -> i.getArgument(0));
 
         LocalDate date = LocalDate.of(2026, 3, 10);
-        service.completeSchedule(schedId, orgId,
-                null, "Done", date, null, null);
+        ServiceCompletion completion =
+                new ServiceCompletion(null, "Done",
+                        date, null, null);
+        service.completeSchedule(
+                schedId, orgId, completion);
 
         verify(recordCreation).createRecord(
-                eq(orgId), any(), any(), eq(sched),
-                eq(null), eq("Done"), eq(date),
-                eq(null), eq(null));
+                eq(orgId), any(), eq(sched),
+                eq(completion));
         verify(schedRepo).save(sched);
     }
 


### PR DESCRIPTION
Introduce two domain records to eliminate parameter clusters:
- ItemSpec groups the 10 item fields that always travel together
- ServiceCompletion groups vendor/summary/date/tech/cost

Also eliminates serviceType tramp data from RecordCreation — the service now extracts it from the schedule when present.