### PR TITLE
Fix code review workflow: add id-token permission, remove invalid inputs

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -10,6 +10,7 @@ env:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   review:
@@ -22,5 +23,3 @@ jobs:
       uses: anthropics/claude-code-action@v1
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-        review_comment_prefix: "**Claude:**"
-        timeout_minutes: 10


### PR DESCRIPTION
- Add `id-token: write` permission required for OIDC token fetching
- Remove `review_comment_prefix` and `timeout_minutes` (not valid inputs for claude-code-action@v1)