### PR TITLE
Extract shared utilities, fix query efficiency, clean up

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/InputValidator.java
+++ b/src/main/java/solutions/mystuff/application/web/InputValidator.java
@@ -39,6 +39,15 @@ public final class InputValidator {
         Validation.requirePositive(value, fieldName);
     }
 
+    /** Parses an ISO date string, or returns null if blank/null. */
+    static LocalDate parseDateOrNull(String value,
+            String fieldName) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return parseDate(value, fieldName);
+    }
+
     /** Parses an ISO date string, throwing on invalid input. */
     static LocalDate parseDate(
             String value, String fieldName) {

--- a/src/main/java/solutions/mystuff/application/web/ItemController.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemController.java
@@ -218,7 +218,8 @@ public class ItemController {
         AppUser user = helper.resolveUser(principal);
         helper.setOrgMdc(user);
         UUID orgId = user.getOrganization().getId();
-        LocalDate pd = parseOptionalDate(purchaseDate);
+        LocalDate pd = InputValidator.parseDateOrNull(
+                purchaseDate, "Purchase date");
         ItemSpec spec = new ItemSpec(name, location,
                 manufacturer, modelName, serialNumber,
                 modelNumber, modelYear, category,
@@ -285,7 +286,8 @@ public class ItemController {
         AppUser user = helper.resolveUser(principal);
         helper.setOrgMdc(user);
         UUID orgId = user.getOrganization().getId();
-        LocalDate pd = parseOptionalDate(purchaseDate);
+        LocalDate pd = InputValidator.parseDateOrNull(
+                purchaseDate, "Purchase date");
         ItemSpec spec = new ItemSpec(name, location,
                 manufacturer, modelName, serialNumber,
                 modelNumber, modelYear, category,
@@ -500,11 +502,4 @@ public class ItemController {
                                 "Item not found"));
     }
 
-    private LocalDate parseOptionalDate(String date) {
-        if (date == null || date.isBlank()) {
-            return null;
-        }
-        return InputValidator.parseDate(
-                date, "Purchase date");
-    }
 }

--- a/src/main/java/solutions/mystuff/application/web/ItemHistoryPdf.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemHistoryPdf.java
@@ -1,6 +1,7 @@
 package solutions.mystuff.application.web;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -211,7 +212,7 @@ final class ItemHistoryPdf {
             return "";
         }
         return "$" + cost.setScale(2,
-                java.math.RoundingMode.HALF_UP)
+                RoundingMode.HALF_UP)
                 .toPlainString();
     }
 }

--- a/src/main/java/solutions/mystuff/application/web/ReportController.java
+++ b/src/main/java/solutions/mystuff/application/web/ReportController.java
@@ -1,8 +1,10 @@
 package solutions.mystuff.application.web;
 
+import java.math.BigDecimal;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -213,12 +215,20 @@ public class ReportController {
 
     private void addCostSummary(
             UUID orgId, Model model) {
+        BigDecimal allTime =
+                costQuery.totalSpendAllTime(orgId);
+        model.addAttribute("totalSpendAllTime", allTime);
         int year = LocalDate.now().getYear();
         model.addAttribute("currentYear", year);
+        if (allTime.signum() == 0) {
+            model.addAttribute("totalSpendThisYear",
+                    BigDecimal.ZERO);
+            model.addAttribute("topItemsByCost",
+                    Collections.emptyList());
+            return;
+        }
         model.addAttribute("totalSpendThisYear",
                 costQuery.totalSpendForYear(orgId, year));
-        model.addAttribute("totalSpendAllTime",
-                costQuery.totalSpendAllTime(orgId));
         model.addAttribute("topItemsByCost",
                 costQuery.topItemsByCost(orgId, 5));
     }

--- a/src/main/java/solutions/mystuff/domain/model/Validation.java
+++ b/src/main/java/solutions/mystuff/domain/model/Validation.java
@@ -32,6 +32,14 @@ public final class Validation {
         }
     }
 
+    /** Returns the trimmed value, or null if blank/null. */
+    public static String trimOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+
     /** Validates that the integer value is at least 1. */
     public static void requirePositive(
             int value, String fieldName) {

--- a/src/main/java/solutions/mystuff/domain/port/out/ServiceRecordRepository.java
+++ b/src/main/java/solutions/mystuff/domain/port/out/ServiceRecordRepository.java
@@ -1,6 +1,7 @@
 package solutions.mystuff.domain.port.out;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -40,9 +41,9 @@ public interface ServiceRecordRepository {
     /** Persist a new or updated service record. */
     ServiceRecord save(ServiceRecord record);
 
-    /** Sum of cost for an organization in a given year. */
-    BigDecimal sumCostByOrganizationAndYear(
-            UUID orgId, int year);
+    /** Sum of cost for an organization in a date range. */
+    BigDecimal sumCostByOrganizationAndDateRange(
+            UUID orgId, LocalDate from, LocalDate to);
 
     /** Sum of cost for an organization across all time. */
     BigDecimal sumCostByOrganization(UUID orgId);

--- a/src/main/java/solutions/mystuff/domain/service/CostQueryService.java
+++ b/src/main/java/solutions/mystuff/domain/service/CostQueryService.java
@@ -1,6 +1,7 @@
 package solutions.mystuff.domain.service;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,6 +32,7 @@ public class CostQueryService implements CostQuery {
 
     private final ServiceRecordRepository recordRepo;
 
+    /** Creates a service backed by the given repository. */
     public CostQueryService(
             ServiceRecordRepository recordRepo) {
         this.recordRepo = recordRepo;
@@ -40,9 +42,11 @@ public class CostQueryService implements CostQuery {
     @Transactional(readOnly = true)
     public BigDecimal totalSpendForYear(
             UUID orgId, int year) {
+        LocalDate from = LocalDate.of(year, 1, 1);
+        LocalDate to = LocalDate.of(year + 1, 1, 1);
         return recordRepo
-                .sumCostByOrganizationAndYear(
-                        orgId, year);
+                .sumCostByOrganizationAndDateRange(
+                        orgId, from, to);
     }
 
     @Override

--- a/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
@@ -107,24 +107,18 @@ public class ItemManagementService
 
     private void setAllFields(
             Item item, ItemSpec spec) {
-        item.setLocation(trimOrNull(spec.location()));
+        item.setLocation(Validation.trimOrNull(spec.location()));
         item.setManufacturer(
-                trimOrNull(spec.manufacturer()));
-        item.setModelName(trimOrNull(spec.modelName()));
+                Validation.trimOrNull(spec.manufacturer()));
+        item.setModelName(Validation.trimOrNull(spec.modelName()));
         item.setSerialNumber(
-                trimOrNull(spec.serialNumber()));
+                Validation.trimOrNull(spec.serialNumber()));
         item.setModelNumber(
-                trimOrNull(spec.modelNumber()));
-        item.setCategory(trimOrNull(spec.category()));
+                Validation.trimOrNull(spec.modelNumber()));
+        item.setCategory(Validation.trimOrNull(spec.category()));
         item.setModelYear(spec.modelYear());
         item.setPurchaseDate(spec.purchaseDate());
-        item.setNotes(trimOrNull(spec.notes()));
+        item.setNotes(Validation.trimOrNull(spec.notes()));
     }
 
-    private String trimOrNull(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        return value.trim();
-    }
 }

--- a/src/main/java/solutions/mystuff/domain/service/VendorManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/VendorManagementService.java
@@ -107,19 +107,19 @@ public class VendorManagementService
     private void applyFields(
             Vendor v, VendorData data) {
         v.setName(data.name().trim());
-        v.setPhone(trimOrNull(data.phone()));
-        v.setEmail(trimOrNull(data.email()));
+        v.setPhone(Validation.trimOrNull(data.phone()));
+        v.setEmail(Validation.trimOrNull(data.email()));
         v.setAddressLine1(
-                trimOrNull(data.addressLine1()));
+                Validation.trimOrNull(data.addressLine1()));
         v.setAddressLine2(
-                trimOrNull(data.addressLine2()));
-        v.setCity(trimOrNull(data.city()));
+                Validation.trimOrNull(data.addressLine2()));
+        v.setCity(Validation.trimOrNull(data.city()));
         v.setStateProvince(
-                trimOrNull(data.stateProvince()));
-        v.setPostalCode(trimOrNull(data.postalCode()));
-        v.setCountry(trimOrNull(data.country()));
-        v.setWebsite(trimOrNull(data.website()));
-        v.setNotes(trimOrNull(data.notes()));
+                Validation.trimOrNull(data.stateProvince()));
+        v.setPostalCode(Validation.trimOrNull(data.postalCode()));
+        v.setCountry(Validation.trimOrNull(data.country()));
+        v.setWebsite(Validation.trimOrNull(data.website()));
+        v.setNotes(Validation.trimOrNull(data.notes()));
         syncAltPhones(v, data);
     }
 
@@ -144,7 +144,7 @@ public class VendorManagementService
             alt.setVendor(v);
             alt.setOrganizationId(v.getOrganizationId());
             alt.setPhone(ap.phone().trim());
-            alt.setLabel(trimOrNull(ap.label()));
+            alt.setLabel(Validation.trimOrNull(ap.label()));
             v.getAltPhones().add(alt);
         }
     }
@@ -167,10 +167,4 @@ public class VendorManagementService
         }
     }
 
-    private String trimOrNull(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        return value.trim();
-    }
 }

--- a/src/main/java/solutions/mystuff/infrastructure/persistence/JpaServiceRecordRepository.java
+++ b/src/main/java/solutions/mystuff/infrastructure/persistence/JpaServiceRecordRepository.java
@@ -1,6 +1,7 @@
 package solutions.mystuff.infrastructure.persistence;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -56,10 +57,12 @@ public interface JpaServiceRecordRepository
     @Query("SELECT COALESCE(SUM(r.cost), 0)"
             + " FROM ServiceRecord r"
             + " WHERE r.organizationId = :orgId"
-            + " AND YEAR(r.serviceDate) = :year")
-    BigDecimal sumCostByOrganizationAndYear(
+            + " AND r.serviceDate >= :from"
+            + " AND r.serviceDate < :to")
+    BigDecimal sumCostByOrganizationAndDateRange(
             @Param("orgId") UUID orgId,
-            @Param("year") int year);
+            @Param("from") LocalDate from,
+            @Param("to") LocalDate to);
 
     @Override
     @Query("SELECT COALESCE(SUM(r.cost), 0)"

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -500,3 +500,61 @@ a.btn-icon:hover {
     object-fit: cover;
     border-radius: 50%;
 }
+
+/* Dashboard */
+
+.dashboard-stats {
+    display: flex;
+    gap: 1rem;
+    margin: 1.5rem 0;
+    flex-wrap: wrap;
+}
+
+.stat-card {
+    flex: 1;
+    min-width: 120px;
+    padding: 1.5rem;
+    border-radius: 8px;
+    text-align: center;
+    background: #e8f5e9;
+}
+
+.stat-card .stat-number {
+    display: block;
+    font-size: 2.5rem;
+    font-weight: bold;
+    line-height: 1.2;
+}
+
+.stat-card .stat-label {
+    display: block;
+    font-size: 0.9rem;
+    color: #555;
+    margin-top: 0.25rem;
+}
+
+.stat-overdue { background: #ffebee; }
+.stat-overdue .stat-number { color: #b71c1c; }
+.stat-due-soon { background: #fffde7; }
+.stat-due-soon .stat-number { color: #f57f17; }
+.stat-items .stat-number { color: #1b5e20; }
+
+.dashboard-links {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 2rem;
+}
+
+.dashboard-links .btn {
+    padding: 0.5rem 1rem;
+    background: #2196F3;
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+}
+
+.dashboard-links .btn:hover { background: #1976D2; }
+
+.recent-activity { margin-top: 1rem; }
+
+.nowrap { white-space: nowrap; }

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -49,7 +49,7 @@
                 </thead>
                 <tbody>
                 <tr th:each="r : ${recentRecords}">
-                    <td th:text="${r.serviceDate}" style="white-space:nowrap"></td>
+                    <td th:text="${r.serviceDate}" class="nowrap"></td>
                     <td th:text="${r.item.name}"></td>
                     <td th:text="${r.serviceType}"></td>
                     <td th:text="${r.summary}"></td>
@@ -59,66 +59,5 @@
         </section>
     </div>
 </main>
-<style>
-.dashboard-stats {
-    display: flex;
-    gap: 1rem;
-    margin: 1.5rem 0;
-    flex-wrap: wrap;
-}
-.stat-card {
-    flex: 1;
-    min-width: 120px;
-    padding: 1.5rem;
-    border-radius: 8px;
-    text-align: center;
-    background: #e8f5e9;
-}
-.stat-card .stat-number {
-    display: block;
-    font-size: 2.5rem;
-    font-weight: bold;
-    line-height: 1.2;
-}
-.stat-card .stat-label {
-    display: block;
-    font-size: 0.9rem;
-    color: #555;
-    margin-top: 0.25rem;
-}
-.stat-overdue {
-    background: #ffebee;
-}
-.stat-overdue .stat-number {
-    color: #b71c1c;
-}
-.stat-due-soon {
-    background: #fffde7;
-}
-.stat-due-soon .stat-number {
-    color: #f57f17;
-}
-.stat-items .stat-number {
-    color: #1b5e20;
-}
-.dashboard-links {
-    display: flex;
-    gap: 0.75rem;
-    margin-bottom: 2rem;
-}
-.dashboard-links .btn {
-    padding: 0.5rem 1rem;
-    background: #2196F3;
-    color: white;
-    text-decoration: none;
-    border-radius: 4px;
-}
-.dashboard-links .btn:hover {
-    background: #1976D2;
-}
-.recent-activity {
-    margin-top: 1rem;
-}
-</style>
 </body>
 </html>

--- a/src/test/java/solutions/mystuff/application/web/DashboardControllerIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/DashboardControllerIntegrationTest.java
@@ -72,14 +72,4 @@ class DashboardControllerIntegrationTest {
                         "noOrganization", true));
     }
 
-    @Test
-    @DisplayName("should include recent records list")
-    void shouldIncludeRecentRecordsWhenUserHasOrg()
-            throws Exception {
-        mockMvc.perform(get("/")
-                        .with(user("dev").roles("USER")))
-                .andExpect(status().isOk())
-                .andExpect(model().attributeExists(
-                        "recentRecords"));
-    }
 }


### PR DESCRIPTION
## Summary
- Extract `trimOrNull` to `Validation` utility (was duplicated in `ItemManagementService` and `VendorManagementService`)
- Move `parseOptionalDate` to `InputValidator.parseDateOrNull` (reusable across controllers)
- Replace `YEAR()` function in cost query with date range condition to enable index use on `service_date`
- Short-circuit cost queries in `ReportController` when all-time spend is zero (skip 2 unnecessary DB queries)
- Move dashboard inline CSS (~60 lines) to main stylesheet
- Add proper `RoundingMode` import in `ItemHistoryPdf`
- Add missing constructor Javadoc on `CostQueryService`
- Remove redundant dashboard integration test

## Test plan
- [x] All 368 tests pass (0 failures, 0 errors)
- [x] Full `mvnw verify` clean (checkstyle, coverage, javadoc)
- [ ] Verify dashboard renders with styles from main stylesheet
- [ ] Verify reports page cost summary still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)