### PR TITLE
Persist page-size preference across navigation

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1,5 +1,24 @@
 document.addEventListener('DOMContentLoaded', function () {
 
+    var pageSizeSelect =
+        document.querySelector('[data-page-size]');
+    if (pageSizeSelect) {
+        var key = 'pageSize.'
+            + pageSizeSelect.getAttribute('data-page-size')
+                .replace(/^\//, '');
+        var params = new URLSearchParams(
+            window.location.search);
+        if (!params.has('size')) {
+            var stored = localStorage.getItem(key);
+            if (stored) {
+                window.location.replace(
+                    window.location.pathname
+                        + '?size=' + stored);
+                return;
+            }
+        }
+    }
+
     function toggleForm(id) {
         var row = document.getElementById(id);
         if (!row) {
@@ -118,6 +137,10 @@ document.addEventListener('DOMContentLoaded', function () {
         if (e.target.matches('[data-page-size]')) {
             var basePath =
                 e.target.getAttribute('data-page-size');
+            var storeKey = 'pageSize.'
+                + basePath.replace(/^\//, '');
+            localStorage.setItem(
+                storeKey, e.target.value);
             window.location.href =
                 basePath + '?size=' + e.target.value;
         }


### PR DESCRIPTION
## Summary
- Store selected page size in `localStorage` (keyed per page: `pageSize.items`, `pageSize.schedules`, `pageSize.vendors`)
- On page load, if no `size` URL parameter is present, apply the stored preference via `window.location.replace()`
- URL parameter remains source of truth; localStorage only seeds the default
- Falls back to server default (10) when JavaScript is disabled

Closes #18

## Test plan
- [ ] Navigate to items page, change page size to 50, navigate away to schedules, navigate back — should still show 50
- [ ] Different pages maintain independent size preferences
- [ ] Direct URL with `?size=25` overrides stored preference
- [ ] Clear localStorage — page uses server default

🤖 Generated with [Claude Code](https://claude.com/claude-code)