### PR TITLE
Validate email format and image upload MIME type

### DIFF
--- a/src/main/java/solutions/mystuff/domain/model/Validation.java
+++ b/src/main/java/solutions/mystuff/domain/model/Validation.java
@@ -1,10 +1,16 @@
 package solutions.mystuff.domain.model;
 
+import java.util.regex.Pattern;
+
 /**
  * Shared validation helpers usable by both domain services
  * and the web layer, eliminating duplicated checks.
  */
 public final class Validation {
+
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile(
+                    "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
 
     private Validation() {
     }
@@ -38,6 +44,18 @@ public final class Validation {
             return null;
         }
         return value.trim();
+    }
+
+    /** Validates that the value is a well-formed email address, if non-null. */
+    public static void requireValidEmail(
+            String value, String fieldName) {
+        if (value != null && !value.isBlank()
+                && !EMAIL_PATTERN.matcher(value.trim())
+                        .matches()) {
+            throw new IllegalArgumentException(
+                    fieldName + " is not a valid"
+                            + " email address");
+        }
     }
 
     /** Validates that the integer value is at least 1. */

--- a/src/main/java/solutions/mystuff/domain/service/ProfileImageServiceImpl.java
+++ b/src/main/java/solutions/mystuff/domain/service/ProfileImageServiceImpl.java
@@ -91,7 +91,7 @@ public class ProfileImageServiceImpl
         userRepo.save(user);
     }
 
-    /** Validates size and resizes the image to exactly 128x128. */
+    /** Validates size, magic bytes, and resizes to 128x128. */
     byte[] resizeImage(
             byte[] imageData, String contentType) {
         if (imageData.length > MAX_BYTES) {
@@ -99,6 +99,7 @@ public class ProfileImageServiceImpl
                     "Image exceeds maximum size of "
                             + MAX_BYTES / 1024 + "KB");
         }
+        validateMagicBytes(imageData, contentType);
         try {
             BufferedImage original = ImageIO.read(
                     new ByteArrayInputStream(imageData));
@@ -123,6 +124,31 @@ public class ProfileImageServiceImpl
             throw new IllegalArgumentException(
                     "Only PNG and JPEG images "
                             + "are supported");
+        }
+    }
+
+    /** Verifies file magic bytes match the declared content type. */
+    static void validateMagicBytes(
+            byte[] data, String contentType) {
+        if (data.length < 4) {
+            throw new IllegalArgumentException(
+                    "Image data too small");
+        }
+        boolean valid = switch (contentType) {
+            case "image/png" -> data[0] == (byte) 0x89
+                    && data[1] == (byte) 0x50
+                    && data[2] == (byte) 0x4E
+                    && data[3] == (byte) 0x47;
+            case "image/jpeg" -> data[0] == (byte) 0xFF
+                    && data[1] == (byte) 0xD8
+                    && data[2] == (byte) 0xFF;
+            default -> false;
+        };
+        if (!valid) {
+            throw new IllegalArgumentException(
+                    "File content does not match"
+                            + " declared type "
+                            + contentType);
         }
     }
 

--- a/src/main/java/solutions/mystuff/domain/service/VendorManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/VendorManagementService.java
@@ -108,6 +108,8 @@ public class VendorManagementService
             Vendor v, VendorData data) {
         v.setName(data.name().trim());
         v.setPhone(Validation.trimOrNull(data.phone()));
+        Validation.requireValidEmail(
+                data.email(), "Vendor email");
         v.setEmail(Validation.trimOrNull(data.email()));
         v.setAddressLine1(
                 Validation.trimOrNull(data.addressLine1()));

--- a/src/test/java/solutions/mystuff/domain/service/ProfileImageServiceImplTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ProfileImageServiceImplTest.java
@@ -194,6 +194,26 @@ class ProfileImageServiceImplTest {
     }
 
     @Test
+    @DisplayName("should reject spoofed content type")
+    void shouldRejectSpoofedContentType() {
+        byte[] textData = "This is not an image"
+                .getBytes();
+        assertThrows(IllegalArgumentException.class,
+                () -> service.resizeImage(
+                        textData, "image/png"));
+    }
+
+    @Test
+    @DisplayName("should reject JPEG bytes with PNG type")
+    void shouldRejectMismatchedMagicBytes()
+            throws Exception {
+        byte[] jpeg = smallJpeg(64, 64);
+        assertThrows(IllegalArgumentException.class,
+                () -> service.resizeImage(
+                        jpeg, "image/png"));
+    }
+
+    @Test
     @DisplayName("should accept JPEG images")
     void shouldAcceptJpeg() throws Exception {
         byte[] jpeg = smallJpeg(64, 64);

--- a/src/test/java/solutions/mystuff/domain/service/VendorManagementServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/VendorManagementServiceTest.java
@@ -290,6 +290,53 @@ class VendorManagementServiceTest {
                 .hasMessageContaining("maximum length");
     }
 
+    @Test
+    @DisplayName("should reject invalid email on create")
+    void shouldRejectInvalidEmailOnCreate() {
+        VendorData data = new VendorData(
+                "Corp", null, "not-an-email",
+                null, null, null, null,
+                null, null, null, null, List.of());
+        assertThatThrownBy(() ->
+                service.createVendor(orgId, data))
+                .isInstanceOf(
+                        IllegalArgumentException.class)
+                .hasMessageContaining("email");
+    }
+
+    @Test
+    @DisplayName("should accept valid email on create")
+    void shouldAcceptValidEmailOnCreate() {
+        when(repo.save(any(Vendor.class)))
+                .thenAnswer(i -> i.getArgument(0));
+
+        VendorData data = new VendorData(
+                "Corp", null, "test@example.com",
+                null, null, null, null,
+                null, null, null, null, List.of());
+        Vendor result = service.createVendor(
+                orgId, data);
+
+        assertThat(result.getEmail())
+                .isEqualTo("test@example.com");
+    }
+
+    @Test
+    @DisplayName("should accept null email on create")
+    void shouldAcceptNullEmailOnCreate() {
+        when(repo.save(any(Vendor.class)))
+                .thenAnswer(i -> i.getArgument(0));
+
+        VendorData data = new VendorData(
+                "Corp", null, null,
+                null, null, null, null,
+                null, null, null, null, List.of());
+        Vendor result = service.createVendor(
+                orgId, data);
+
+        assertThat(result.getEmail()).isNull();
+    }
+
     private Vendor existingVendor(UUID vendorId) {
         Vendor v = new Vendor();
         v.setName("Old Name");


### PR DESCRIPTION
## Summary
- Add `Validation.requireValidEmail()` — rejects malformed email addresses on vendor create/update
- Add `ProfileImageServiceImpl.validateMagicBytes()` — verifies PNG/JPEG magic bytes match declared content type, preventing spoofed uploads
- Both validations return clear `IllegalArgumentException` messages
- Null/blank emails remain accepted (optional field)

Closes #17

## Test plan
- [ ] Create vendor with invalid email (e.g., "not-an-email") — should get 400 error
- [ ] Create vendor with valid email — should succeed
- [ ] Create vendor with no email — should succeed
- [ ] Upload a text file renamed to .png — should get rejected
- [ ] Upload valid PNG/JPEG — should succeed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)