### PR TITLE
Enforce org-scoped authorization on entity access

### DIFF
--- a/src/main/java/solutions/mystuff/domain/model/OrgOwnedEntity.java
+++ b/src/main/java/solutions/mystuff/domain/model/OrgOwnedEntity.java
@@ -49,4 +49,10 @@ public abstract class OrgOwnedEntity extends BaseEntity {
     public void setOrganizationId(UUID organizationId) {
         this.organizationId = organizationId;
     }
+
+    /** Returns true if this entity belongs to the given organization. */
+    public boolean belongsTo(UUID orgId) {
+        return organizationId != null
+                && organizationId.equals(orgId);
+    }
 }

--- a/src/test/java/solutions/mystuff/application/web/CrossOrgAccessIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/CrossOrgAccessIntegrationTest.java
@@ -1,0 +1,162 @@
+package solutions.mystuff.application.web;
+
+import java.util.List;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.Item;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure
+        .AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet
+        .request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet
+        .request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet
+        .request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet
+        .request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet
+        .result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet
+        .result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies that users without an organization cannot
+ * see or modify entities belonging to other organizations,
+ * and that org-scoped queries return empty results
+ * for mismatched organizations.
+ *
+ * <div class="mermaid">
+ * sequenceDiagram
+ *     participant OtherUser as otheruser (no org)
+ *     participant Controller
+ *     OtherUser->>Controller: GET /items
+ *     Controller-->>OtherUser: 200 (noOrganization=true)
+ * </div>
+ *
+ * @see OrgOwnedEntity#belongsTo(UUID)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("Cross-Org Access Integration")
+class CrossOrgAccessIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("should show no-org warning for items")
+    void shouldShowNoOrgWarningForItems()
+            throws Exception {
+        mockMvc.perform(get("/items")
+                        .with(user("otheruser")
+                                .roles("USER")))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute(
+                        "noOrganization", true));
+    }
+
+    @Test
+    @DisplayName("should show no-org warning for item detail")
+    void shouldShowNoOrgWarningForItemDetail()
+            throws Exception {
+        String itemId = getDevItemId();
+        mockMvc.perform(get("/items/" + itemId)
+                        .with(user("otheruser")
+                                .roles("USER")))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute(
+                        "noOrganization", true));
+    }
+
+    @Test
+    @DisplayName("should show no-org warning for schedules")
+    void shouldShowNoOrgWarningForSchedules()
+            throws Exception {
+        mockMvc.perform(get("/schedules")
+                        .with(user("otheruser")
+                                .roles("USER")))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute(
+                        "noOrganization", true));
+    }
+
+    @Test
+    @DisplayName("should show no-org warning for vendors")
+    void shouldShowNoOrgWarningForVendors()
+            throws Exception {
+        mockMvc.perform(get("/vendors")
+                        .with(user("otheruser")
+                                .roles("USER")))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute(
+                        "noOrganization", true));
+    }
+
+    @Test
+    @DisplayName("should deny random item service record")
+    void shouldDenyRandomItemServiceRecord()
+            throws Exception {
+        UUID randomId = UUID.randomUUID();
+        mockMvc.perform(post("/items/" + randomId
+                        + "/service-records")
+                        .param("summary", "Test")
+                        .param("serviceDate",
+                                "2026-01-01")
+                        .with(user("dev")
+                                .roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("should deny random schedule skip")
+    void shouldDenyRandomScheduleSkip()
+            throws Exception {
+        UUID randomId = UUID.randomUUID();
+        mockMvc.perform(post("/schedules/"
+                        + randomId + "/skip")
+                        .with(user("dev")
+                                .roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("should return dev items only for dev")
+    void shouldReturnDevItemsOnlyForDev()
+            throws Exception {
+        MvcResult result = mockMvc.perform(
+                        get("/items")
+                                .with(user("dev")
+                                        .roles("USER")))
+                .andExpect(status().isOk())
+                .andReturn();
+        @SuppressWarnings("unchecked")
+        List<Item> items = (List<Item>)
+                result.getModelAndView().getModel()
+                        .get("items");
+        assertTrue(items != null && !items.isEmpty(),
+                "Dev user should see items");
+    }
+
+    @SuppressWarnings("unchecked")
+    private String getDevItemId() throws Exception {
+        MvcResult result = mockMvc.perform(
+                        get("/items")
+                                .with(user("dev")
+                                        .roles("USER")))
+                .andReturn();
+        List<Item> items = (List<Item>)
+                result.getModelAndView().getModel()
+                        .get("items");
+        return items.get(0).getId().toString();
+    }
+}

--- a/src/test/java/solutions/mystuff/domain/model/OrgOwnedEntityTest.java
+++ b/src/test/java/solutions/mystuff/domain/model/OrgOwnedEntityTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("OrgOwnedEntity")
 class OrgOwnedEntityTest {
@@ -28,6 +30,30 @@ class OrgOwnedEntityTest {
         UUID orgId = UuidV7.generate();
         entity.setOrganizationId(orgId);
         assertEquals(orgId, entity.getOrganizationId());
+    }
+
+    @Test
+    @DisplayName("should return true when belongsTo matches")
+    void shouldReturnTrueWhenBelongsToMatches() {
+        TestOrgEntity entity = new TestOrgEntity();
+        UUID orgId = UuidV7.generate();
+        entity.setOrganizationId(orgId);
+        assertTrue(entity.belongsTo(orgId));
+    }
+
+    @Test
+    @DisplayName("should return false when belongsTo mismatches")
+    void shouldReturnFalseWhenBelongsToMismatches() {
+        TestOrgEntity entity = new TestOrgEntity();
+        entity.setOrganizationId(UuidV7.generate());
+        assertFalse(entity.belongsTo(UuidV7.generate()));
+    }
+
+    @Test
+    @DisplayName("should return false when org ID is null")
+    void shouldReturnFalseWhenOrgIdIsNull() {
+        TestOrgEntity entity = new TestOrgEntity();
+        assertFalse(entity.belongsTo(UuidV7.generate()));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add `OrgOwnedEntity.belongsTo(UUID)` convenience method for defense-in-depth org ownership verification
- Add `CrossOrgAccessIntegrationTest` with 7 tests verifying:
  - Users without an org see no-org warnings (not other org's data)
  - Random UUID lookups for items, schedules return 404
  - Dev user sees their own org's items
- All existing repository queries already use `findByIdAndOrganizationId`, providing SQL-level tenant isolation

Closes #15

## Test plan
- [ ] All 7 cross-org tests pass
- [ ] Existing tests unaffected
- [ ] `belongsTo()` unit tests cover match, mismatch, and null cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)