### PR TITLE
Build REST API endpoints for items, schedules, and vendors

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/LinkHeaderBuilder.java
+++ b/src/main/java/solutions/mystuff/application/web/LinkHeaderBuilder.java
@@ -12,13 +12,13 @@ import jakarta.servlet.http.HttpServletResponse;
  * @see ItemController
  * @see ScheduleController
  */
-final class LinkHeaderBuilder {
+public final class LinkHeaderBuilder {
 
     private LinkHeaderBuilder() {
     }
 
     /** Builds and sets the Link header with prev/next rels. */
-    static void addLinkHeader(
+    public static void addLinkHeader(
             HttpServletResponse response,
             String basePath,
             PageResult<?> page, String q) {

--- a/src/main/java/solutions/mystuff/application/web/api/ItemApiController.java
+++ b/src/main/java/solutions/mystuff/application/web/api/ItemApiController.java
@@ -1,0 +1,137 @@
+package solutions.mystuff.application.web.api;
+
+import java.security.Principal;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.AppUser;
+import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.ItemSpec;
+import solutions.mystuff.domain.model.NotFoundException;
+import solutions.mystuff.domain.model.PageResult;
+import solutions.mystuff.domain.port.in.ItemManagement;
+import solutions.mystuff.domain.port.in.ItemQuery;
+import solutions.mystuff.domain.port.in.UserResolver;
+import solutions.mystuff.application.web.LinkHeaderBuilder;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST API for item CRUD operations.
+ *
+ * <div class="mermaid">
+ * sequenceDiagram
+ *     Client->>ItemApiController: GET /api/v1/items
+ *     ItemApiController->>UserResolver: resolveOrCreate
+ *     ItemApiController->>ItemQuery: findByOrganization
+ *     ItemApiController-->>Client: JSON PageResponse
+ * </div>
+ *
+ * @see ItemQuery
+ * @see ItemManagement
+ */
+@RestController
+@RequestMapping("/api/v1/items")
+@Tag(name = "Items API",
+        description = "REST API for item management")
+public class ItemApiController {
+
+    private final ItemQuery itemQuery;
+    private final ItemManagement itemService;
+    private final UserResolver userResolver;
+
+    /** Creates an item API controller. */
+    public ItemApiController(
+            ItemQuery itemQuery,
+            ItemManagement itemService,
+            UserResolver userResolver) {
+        this.itemQuery = itemQuery;
+        this.itemService = itemService;
+        this.userResolver = userResolver;
+    }
+
+    /** Lists items with pagination and optional search. */
+    @Operation(summary = "List items")
+    @GetMapping
+    public PageResponse<ItemResponse> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String q,
+            Principal principal,
+            HttpServletResponse response) {
+        UUID orgId = resolveOrgId(principal);
+        int clamped = Math.max(1,
+                Math.min(size, 100));
+        PageResult<Item> result = q != null
+                && !q.isBlank()
+                ? itemQuery.searchByOrganization(
+                        orgId, q, page, clamped)
+                : itemQuery.findByOrganization(
+                        orgId, page, clamped);
+        LinkHeaderBuilder.addLinkHeader(
+                response, "/api/v1/items",
+                result, q);
+        return PageResponse.from(
+                result, ItemResponse::from);
+    }
+
+    /** Gets a single item by ID. */
+    @Operation(summary = "Get item by ID")
+    @GetMapping("/{id}")
+    public ItemResponse get(
+            @PathVariable UUID id,
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        Item item = itemQuery
+                .findByIdAndOrganization(id, orgId)
+                .orElseThrow(() ->
+                        new NotFoundException(
+                                "Item not found"));
+        return ItemResponse.from(item);
+    }
+
+    /** Creates a new item. */
+    @Operation(summary = "Create item")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ItemResponse create(
+            @RequestBody ItemSpec spec,
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        return ItemResponse.from(
+                itemService.createItem(orgId, spec));
+    }
+
+    /** Updates an existing item. */
+    @Operation(summary = "Update item")
+    @PutMapping("/{id}")
+    public ItemResponse update(
+            @PathVariable UUID id,
+            @RequestBody ItemSpec spec,
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        return ItemResponse.from(
+                itemService.updateItem(
+                        orgId, id, spec));
+    }
+
+    private UUID resolveOrgId(Principal principal) {
+        AppUser user = userResolver.resolveOrCreate(
+                principal.getName());
+        if (!user.hasOrganization()) {
+            throw new IllegalArgumentException(
+                    "No organization assigned");
+        }
+        return user.getOrganization().getId();
+    }
+}

--- a/src/main/java/solutions/mystuff/application/web/api/ItemResponse.java
+++ b/src/main/java/solutions/mystuff/application/web/api/ItemResponse.java
@@ -1,0 +1,54 @@
+package solutions.mystuff.application.web.api;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.Item;
+
+/**
+ * JSON response DTO for an item, avoiding lazy-load issues.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class ItemResponse {
+ *         UUID id
+ *         String name
+ *         String location
+ *         String manufacturer
+ *         String modelName
+ *         String category
+ *     }
+ *     ItemResponse ..&gt; Item : from
+ * </div>
+ *
+ * @see ItemApiController
+ */
+public record ItemResponse(
+        UUID id,
+        String name,
+        String location,
+        String manufacturer,
+        String modelName,
+        String modelNumber,
+        Integer modelYear,
+        String serialNumber,
+        String category,
+        LocalDate purchaseDate,
+        String notes) {
+
+    /** Creates a response DTO from a domain Item. */
+    public static ItemResponse from(Item item) {
+        return new ItemResponse(
+                item.getId(),
+                item.getName(),
+                item.getLocation(),
+                item.getManufacturer(),
+                item.getModelName(),
+                item.getModelNumber(),
+                item.getModelYear(),
+                item.getSerialNumber(),
+                item.getCategory(),
+                item.getPurchaseDate(),
+                item.getNotes());
+    }
+}

--- a/src/main/java/solutions/mystuff/application/web/api/PageResponse.java
+++ b/src/main/java/solutions/mystuff/application/web/api/PageResponse.java
@@ -1,0 +1,44 @@
+package solutions.mystuff.application.web.api;
+
+import java.util.List;
+import java.util.function.Function;
+
+import solutions.mystuff.domain.model.PageResult;
+
+/**
+ * JSON-safe pagination wrapper that maps domain entities
+ * to response DTOs.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class PageResponse {
+ *         List content
+ *         int page
+ *         int size
+ *         boolean hasNext
+ *     }
+ * </div>
+ *
+ * @param <T> the DTO element type
+ * @see PageResult
+ */
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        boolean hasNext) {
+
+    /** Maps a PageResult to a PageResponse using a mapper. */
+    public static <S, T> PageResponse<T> from(
+            PageResult<S> source,
+            Function<S, T> mapper) {
+        List<T> mapped = source.content().stream()
+                .map(mapper)
+                .toList();
+        return new PageResponse<>(
+                mapped,
+                source.page(),
+                source.size(),
+                source.hasNext());
+    }
+}

--- a/src/main/java/solutions/mystuff/application/web/api/ScheduleApiController.java
+++ b/src/main/java/solutions/mystuff/application/web/api/ScheduleApiController.java
@@ -1,0 +1,127 @@
+package solutions.mystuff.application.web.api;
+
+import java.security.Principal;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.AppUser;
+import solutions.mystuff.domain.model.PageResult;
+import solutions.mystuff.domain.model.ServiceCompletion;
+import solutions.mystuff.domain.model.ServiceSchedule;
+import solutions.mystuff.domain.port.in.ScheduleLifecycle;
+import solutions.mystuff.domain.port.in.ScheduleQuery;
+import solutions.mystuff.domain.port.in.UserResolver;
+import solutions.mystuff.application.web.LinkHeaderBuilder;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST API for schedule operations.
+ *
+ * <div class="mermaid">
+ * sequenceDiagram
+ *     Client->>ScheduleApiController: GET /api/v1/schedules
+ *     ScheduleApiController->>ScheduleQuery: findActive
+ *     ScheduleApiController-->>Client: JSON PageResponse
+ * </div>
+ *
+ * @see ScheduleQuery
+ * @see ScheduleLifecycle
+ */
+@RestController
+@RequestMapping("/api/v1/schedules")
+@Tag(name = "Schedules API",
+        description = "REST API for schedule management")
+public class ScheduleApiController {
+
+    private final ScheduleQuery scheduleQuery;
+    private final ScheduleLifecycle scheduleService;
+    private final UserResolver userResolver;
+
+    /** Creates a schedule API controller. */
+    public ScheduleApiController(
+            ScheduleQuery scheduleQuery,
+            ScheduleLifecycle scheduleService,
+            UserResolver userResolver) {
+        this.scheduleQuery = scheduleQuery;
+        this.scheduleService = scheduleService;
+        this.userResolver = userResolver;
+    }
+
+    /** Lists active schedules with pagination. */
+    @Operation(summary = "List active schedules")
+    @GetMapping
+    public PageResponse<ScheduleResponse> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Principal principal,
+            HttpServletResponse response) {
+        UUID orgId = resolveOrgId(principal);
+        int clamped = Math.max(1,
+                Math.min(size, 100));
+        PageResult<ServiceSchedule> result =
+                scheduleQuery.findActiveByOrganization(
+                        orgId, page, clamped);
+        LinkHeaderBuilder.addLinkHeader(
+                response, "/api/v1/schedules",
+                result, null);
+        return PageResponse.from(
+                result, ScheduleResponse::from);
+    }
+
+    /** Completes a schedule and logs a service record. */
+    @Operation(summary = "Complete schedule")
+    @PostMapping("/{id}/completions")
+    public ScheduleResponse complete(
+            @PathVariable UUID id,
+            @RequestBody ServiceCompletion completion,
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        return ScheduleResponse.from(
+                scheduleService.completeSchedule(
+                        id, orgId, completion));
+    }
+
+    /** Skips the current occurrence. */
+    @Operation(summary = "Skip schedule")
+    @PostMapping("/{id}/skip")
+    public ScheduleResponse skip(
+            @PathVariable UUID id,
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        return ScheduleResponse.from(
+                scheduleService.skipSchedule(
+                        id, orgId));
+    }
+
+    /** Deactivates a schedule. */
+    @Operation(summary = "Deactivate schedule")
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deactivate(
+            @PathVariable UUID id,
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        scheduleService.deactivateSchedule(id, orgId);
+    }
+
+    private UUID resolveOrgId(Principal principal) {
+        AppUser user = userResolver.resolveOrCreate(
+                principal.getName());
+        if (!user.hasOrganization()) {
+            throw new IllegalArgumentException(
+                    "No organization assigned");
+        }
+        return user.getOrganization().getId();
+    }
+}

--- a/src/main/java/solutions/mystuff/application/web/api/ScheduleResponse.java
+++ b/src/main/java/solutions/mystuff/application/web/api/ScheduleResponse.java
@@ -1,0 +1,55 @@
+package solutions.mystuff.application.web.api;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.FrequencyUnit;
+import solutions.mystuff.domain.model.ServiceSchedule;
+
+/**
+ * JSON response DTO for a service schedule.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class ScheduleResponse {
+ *         UUID id
+ *         String serviceType
+ *         LocalDate nextDueDate
+ *     }
+ *     ScheduleResponse ..&gt; ServiceSchedule : from
+ * </div>
+ *
+ * @see ScheduleApiController
+ */
+public record ScheduleResponse(
+        UUID id,
+        String itemName,
+        UUID itemId,
+        String serviceType,
+        String vendorName,
+        LocalDate nextDueDate,
+        LocalDate lastCompletedDate,
+        int frequencyInterval,
+        FrequencyUnit frequencyUnit,
+        boolean active) {
+
+    /** Creates a response from a domain schedule. */
+    public static ScheduleResponse from(
+            ServiceSchedule s) {
+        return new ScheduleResponse(
+                s.getId(),
+                s.getItem() != null
+                        ? s.getItem().getName() : null,
+                s.getItem() != null
+                        ? s.getItem().getId() : null,
+                s.getServiceType(),
+                s.getPreferredVendor() != null
+                        ? s.getPreferredVendor().getName()
+                        : null,
+                s.getNextDueDate(),
+                s.getLastCompletedDate(),
+                s.getFrequencyInterval(),
+                s.getFrequencyUnit(),
+                s.isActive());
+    }
+}

--- a/src/main/java/solutions/mystuff/application/web/api/VendorApiController.java
+++ b/src/main/java/solutions/mystuff/application/web/api/VendorApiController.java
@@ -1,0 +1,133 @@
+package solutions.mystuff.application.web.api;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.AppUser;
+import solutions.mystuff.domain.model.NotFoundException;
+import solutions.mystuff.domain.model.Vendor;
+import solutions.mystuff.domain.model.VendorData;
+import solutions.mystuff.domain.port.in.UserResolver;
+import solutions.mystuff.domain.port.in.VendorManagement;
+import solutions.mystuff.domain.port.in.VendorQuery;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST API for vendor CRUD operations.
+ *
+ * <div class="mermaid">
+ * sequenceDiagram
+ *     Client->>VendorApiController: GET /api/v1/vendors
+ *     VendorApiController->>UserResolver: resolveOrCreate
+ *     VendorApiController->>VendorQuery: findAllVendors
+ *     VendorApiController-->>Client: JSON List
+ * </div>
+ *
+ * @see VendorQuery
+ * @see VendorManagement
+ */
+@RestController
+@RequestMapping("/api/v1/vendors")
+@Tag(name = "Vendors API",
+        description = "REST API for vendor management")
+public class VendorApiController {
+
+    private final VendorQuery vendorQuery;
+    private final VendorManagement vendorService;
+    private final UserResolver userResolver;
+
+    /** Creates a vendor API controller. */
+    public VendorApiController(
+            VendorQuery vendorQuery,
+            VendorManagement vendorService,
+            UserResolver userResolver) {
+        this.vendorQuery = vendorQuery;
+        this.vendorService = vendorService;
+        this.userResolver = userResolver;
+    }
+
+    /** Lists all vendors for the organization. */
+    @Operation(summary = "List vendors")
+    @GetMapping
+    public List<VendorResponse> list(
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        return vendorQuery.findAllVendors(orgId)
+                .stream()
+                .map(VendorResponse::from)
+                .toList();
+    }
+
+    /** Gets a single vendor by ID. */
+    @Operation(summary = "Get vendor by ID")
+    @GetMapping("/{id}")
+    public VendorResponse get(
+            @PathVariable UUID id,
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        Vendor v = vendorQuery.findVendor(id, orgId)
+                .orElseThrow(() ->
+                        new NotFoundException(
+                                "Vendor not found"));
+        return VendorResponse.from(v);
+    }
+
+    /** Creates a new vendor. */
+    @Operation(summary = "Create vendor")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public VendorResponse create(
+            @RequestBody VendorData data,
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        return VendorResponse.from(
+                vendorService.createVendor(
+                        orgId, data));
+    }
+
+    /** Updates an existing vendor. */
+    @Operation(summary = "Update vendor")
+    @PutMapping("/{id}")
+    public VendorResponse update(
+            @PathVariable UUID id,
+            @RequestBody VendorData data,
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        return VendorResponse.from(
+                vendorService.updateVendor(
+                        orgId, id, data));
+    }
+
+    /** Deletes a vendor. */
+    @Operation(summary = "Delete vendor")
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @PathVariable UUID id,
+            Principal principal) {
+        UUID orgId = resolveOrgId(principal);
+        vendorService.deleteVendor(orgId, id);
+    }
+
+    private UUID resolveOrgId(Principal principal) {
+        AppUser user = userResolver.resolveOrCreate(
+                principal.getName());
+        if (!user.hasOrganization()) {
+            throw new IllegalArgumentException(
+                    "No organization assigned");
+        }
+        return user.getOrganization().getId();
+    }
+}

--- a/src/main/java/solutions/mystuff/application/web/api/VendorResponse.java
+++ b/src/main/java/solutions/mystuff/application/web/api/VendorResponse.java
@@ -1,0 +1,56 @@
+package solutions.mystuff.application.web.api;
+
+import java.util.List;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.Vendor;
+
+/**
+ * JSON response DTO for a vendor.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class VendorResponse {
+ *         UUID id
+ *         String name
+ *         String phone
+ *         String email
+ *     }
+ *     VendorResponse ..&gt; Vendor : from
+ * </div>
+ *
+ * @see VendorApiController
+ */
+public record VendorResponse(
+        UUID id,
+        String name,
+        String phone,
+        String email,
+        String city,
+        String stateProvince,
+        String website,
+        List<AltPhone> altPhones) {
+
+    /** Alt phone sub-record. */
+    public record AltPhone(
+            String phone, String label) {
+    }
+
+    /** Creates a response DTO from a domain Vendor. */
+    public static VendorResponse from(Vendor v) {
+        List<AltPhone> phones = v.getAltPhones()
+                .stream()
+                .map(ap -> new AltPhone(
+                        ap.getPhone(), ap.getLabel()))
+                .toList();
+        return new VendorResponse(
+                v.getId(),
+                v.getName(),
+                v.getPhone(),
+                v.getEmail(),
+                v.getCity(),
+                v.getStateProvince(),
+                v.getWebsite(),
+                phones);
+    }
+}

--- a/src/test/java/solutions/mystuff/application/web/api/RestApiIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/api/RestApiIntegrationTest.java
@@ -1,0 +1,191 @@
+package solutions.mystuff.application.web.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure
+        .AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet
+        .request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet
+        .request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet
+        .request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet
+        .result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet
+        .result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for the v1 REST API controllers.
+ *
+ * <div class="mermaid">
+ * sequenceDiagram
+ *     Test->>AuthController: POST /api/auth/token
+ *     AuthController-->>Test: JWT
+ *     Test->>ItemApiController: GET /api/v1/items
+ *     ItemApiController-->>Test: 200 JSON
+ * </div>
+ *
+ * @see ItemApiController
+ * @see VendorApiController
+ * @see ScheduleApiController
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("REST API Integration")
+class RestApiIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private String token;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MvcResult result = mockMvc.perform(
+                post("/api/auth/token")
+                        .contentType(
+                                MediaType.APPLICATION_JSON)
+                        .content(
+                                "{\"username\":\"dev\","
+                                + "\"password\":\"dev\"}"))
+                .andReturn();
+        String body = result.getResponse()
+                .getContentAsString();
+        token = body.replaceAll(
+                ".*\"token\":\"([^\"]+)\".*", "$1");
+    }
+
+    @Test
+    @DisplayName("should list items")
+    void shouldListItems() throws Exception {
+        mockMvc.perform(get("/api/v1/items")
+                        .header("Authorization",
+                                "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content",
+                        notNullValue()))
+                .andExpect(jsonPath("$.content.length()",
+                        greaterThan(0)));
+    }
+
+    @Test
+    @DisplayName("should get item by ID")
+    void shouldGetItemById() throws Exception {
+        String itemId = getFirstItemId();
+        mockMvc.perform(get("/api/v1/items/" + itemId)
+                        .header("Authorization",
+                                "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name",
+                        notNullValue()));
+    }
+
+    @Test
+    @DisplayName("should create item")
+    void shouldCreateItem() throws Exception {
+        mockMvc.perform(post("/api/v1/items")
+                        .header("Authorization",
+                                "Bearer " + token)
+                        .contentType(
+                                MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"API Test"
+                                + " Item\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name")
+                        .value("API Test Item"));
+    }
+
+    @Test
+    @DisplayName("should update item")
+    void shouldUpdateItem() throws Exception {
+        String itemId = getFirstItemId();
+        mockMvc.perform(put("/api/v1/items/" + itemId)
+                        .header("Authorization",
+                                "Bearer " + token)
+                        .contentType(
+                                MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Updated"
+                                + " via API\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name")
+                        .value("Updated via API"));
+    }
+
+    @Test
+    @DisplayName("should return 404 for unknown item")
+    void shouldReturn404ForUnknownItem()
+            throws Exception {
+        String fakeId =
+                "00000000-0000-0000-0000-000000000000";
+        mockMvc.perform(get("/api/v1/items/" + fakeId)
+                        .header("Authorization",
+                                "Bearer " + token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("should list vendors")
+    void shouldListVendors() throws Exception {
+        mockMvc.perform(get("/api/v1/vendors")
+                        .header("Authorization",
+                                "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()",
+                        greaterThan(0)));
+    }
+
+    @Test
+    @DisplayName("should create vendor")
+    void shouldCreateVendor() throws Exception {
+        mockMvc.perform(post("/api/v1/vendors")
+                        .header("Authorization",
+                                "Bearer " + token)
+                        .contentType(
+                                MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"API Vendor"
+                                + "\",\"altPhones\":[]}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name")
+                        .value("API Vendor"));
+    }
+
+    @Test
+    @DisplayName("should list schedules")
+    void shouldListSchedules() throws Exception {
+        mockMvc.perform(get("/api/v1/schedules")
+                        .header("Authorization",
+                                "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content",
+                        notNullValue()));
+    }
+
+    @Test
+    @DisplayName("should require auth for API")
+    void shouldRequireAuthForApi() throws Exception {
+        mockMvc.perform(get("/api/v1/items"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private String getFirstItemId() throws Exception {
+        MvcResult result = mockMvc.perform(
+                get("/api/v1/items")
+                        .header("Authorization",
+                                "Bearer " + token))
+                .andReturn();
+        String body = result.getResponse()
+                .getContentAsString();
+        return body.replaceAll(
+                ".*?\"id\":\"([^\"]+)\".*", "$1");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ItemApiController`, `VendorApiController`, `ScheduleApiController` under `/api/v1/`
- All endpoints secured with JWT (via existing `JwtAuthenticationFilter`)
- Response DTOs (`ItemResponse`, `VendorResponse`, `ScheduleResponse`, `PageResponse`) prevent Hibernate lazy-load serialization issues
- Paginated endpoints include RFC 8288 Link headers via `LinkHeaderBuilder`
- OpenAPI annotations auto-generate Swagger docs
- 9 integration tests covering CRUD, auth, and 404 scenarios

Closes #19

## Test plan
- [ ] `POST /api/auth/token` with dev/dev credentials returns JWT
- [ ] `GET /api/v1/items` with Bearer token returns paginated items
- [ ] `POST /api/v1/items` creates item, returns 201
- [ ] `PUT /api/v1/items/{id}` updates item
- [ ] `GET /api/v1/vendors` returns vendor list
- [ ] `POST /api/v1/vendors` creates vendor, returns 201
- [ ] `GET /api/v1/schedules` returns paginated schedules
- [ ] Unauthenticated requests return 401
- [ ] Unknown IDs return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)