### PR TITLE
Simplify: consolidate validation utilities and fix stale docs

### DIFF
--- a/src/main/java/solutions/mystuff/domain/port/out/ServiceRecordRepository.java
+++ b/src/main/java/solutions/mystuff/domain/port/out/ServiceRecordRepository.java
@@ -41,7 +41,7 @@ public interface ServiceRecordRepository {
     /** Persist a new or updated service record. */
     ServiceRecord save(ServiceRecord record);
 
-    /** Sum of cost for an organization in a date range. */
+    /** Sum of cost for an organization in a half-open date range [from, to). */
     BigDecimal sumCostByOrganizationAndDateRange(
             UUID orgId, LocalDate from, LocalDate to);
 

--- a/src/main/java/solutions/mystuff/domain/service/CostQueryService.java
+++ b/src/main/java/solutions/mystuff/domain/service/CostQueryService.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation
  * <div class="mermaid">
  * sequenceDiagram
  *     Controller->>CostQueryService: totalSpendForYear
- *     CostQueryService->>ServiceRecordRepository: sumCostByOrganizationAndYear
+ *     CostQueryService->>ServiceRecordRepository: sumCostByOrganizationAndDateRange
  *     ServiceRecordRepository-->>CostQueryService: BigDecimal
  *     CostQueryService-->>Controller: BigDecimal
  * </div>

--- a/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
+++ b/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
@@ -7,6 +7,7 @@ import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.ServiceRecord;
 import solutions.mystuff.domain.model.ServiceSchedule;
+import solutions.mystuff.domain.model.Validation;
 import solutions.mystuff.domain.port.in.RecordCreation;
 import solutions.mystuff.domain.port.out
         .ServiceRecordRepository;
@@ -65,11 +66,9 @@ public class RecordCreationService
         record.setVendor(completion.vendor());
         record.setServiceDate(completion.serviceDate());
         record.setSummary(completion.summary().trim());
-        if (completion.techName() != null
-                && !completion.techName().isBlank()) {
-            record.setTechnicianName(
-                    completion.techName().trim());
-        }
+        record.setTechnicianName(
+                Validation.trimOrNull(
+                        completion.techName()));
         record.setCost(completion.cost() != null
                 ? completion.cost() : BigDecimal.ZERO);
         recordRepo.save(record);
@@ -78,23 +77,13 @@ public class RecordCreationService
     }
 
     private void validateSummary(String summary) {
-        if (summary == null || summary.isBlank()) {
-            throw new IllegalArgumentException(
-                    "Summary is required");
-        }
-        if (summary.trim().length() > MAX_SUMMARY) {
-            throw new IllegalArgumentException(
-                    "Summary exceeds maximum length of "
-                            + MAX_SUMMARY);
-        }
+        Validation.requireNotBlank(summary, "Summary");
+        Validation.requireMaxLength(
+                summary, "Summary", MAX_SUMMARY);
     }
 
     private void validateTechName(String techName) {
-        if (techName != null
-                && techName.trim().length() > MAX_TECH) {
-            throw new IllegalArgumentException(
-                    "Technician exceeds maximum length"
-                            + " of " + MAX_TECH);
-        }
+        Validation.requireMaxLength(
+                techName, "Technician", MAX_TECH);
     }
 }

--- a/src/main/java/solutions/mystuff/domain/service/VendorManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/VendorManagementService.java
@@ -55,9 +55,7 @@ public class VendorManagementService
                 VendorFieldLimits.MAX_PHONE);
         Vendor vendor = newVendor(orgId);
         vendor.setName(name.trim());
-        if (phone != null && !phone.isBlank()) {
-            vendor.setPhone(phone.trim());
-        }
+        vendor.setPhone(Validation.trimOrNull(phone));
         return vendorRepository.save(vendor);
     }
 


### PR DESCRIPTION
## Summary
- Replace remaining hand-rolled null/blank-then-trim patterns in `VendorManagementService` and `RecordCreationService` with `Validation.trimOrNull()`
- Replace duplicated validation logic in `RecordCreationService` with shared `Validation.requireNotBlank()` and `requireMaxLength()`
- Fix stale Javadoc in `CostQueryService` referencing old `sumCostByOrganizationAndYear` method name
- Document half-open `[from, to)` interval contract on `sumCostByOrganizationAndDateRange`

## Test plan
- [ ] CI passes (compilation, checkstyle, tests, coverage)
- [ ] Verify vendor creation with blank phone still results in null phone
- [ ] Verify service record creation with blank tech name still results in null tech name

🤖 Generated with [Claude Code](https://claude.com/claude-code)