### PR TITLE
Add purchase date column to items list view

### DIFF
--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -87,6 +87,7 @@
                     <th>Manufacturer</th>
                     <th>Model</th>
                     <th>Serial #</th>
+                    <th>Purchased</th>
                     <th>Actions</th>
                 </tr>
                 </thead>
@@ -101,6 +102,7 @@
                     <td th:text="${item.manufacturer}"></td>
                     <td th:text="${item.modelName}"></td>
                     <td th:text="${item.serialNumber}"></td>
+                    <td th:text="${item.purchaseDate}" class="nowrap"></td>
                     <td class="actions">
                         <button type="button" class="btn-icon btn-edit" title="Edit item"
                                 th:data-target="'edit-item-' + ${item.id}">
@@ -117,7 +119,7 @@
                     </td>
                 </tr>
                 <tr th:id="'edit-item-' + ${item.id}" class="form-row" style="display:none">
-                    <td colspan="7">
+                    <td colspan="8">
                         <form th:action="@{/items/{id}(id=${item.id})}" method="post" class="inline-form">
                             <input type="hidden" name="_method" value="PUT"/>
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
@@ -155,7 +157,7 @@
                     </td>
                 </tr>
                 <tr th:id="'item-oneoff-' + ${item.id}" class="form-row" style="display:none">
-                    <td colspan="7">
+                    <td colspan="8">
                         <form method="post" th:action="@{/items/{id}/service-records(id=${item.id})}" class="inline-form">
                             <input type="hidden" name="oneOff" value="true"/>
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
@@ -180,7 +182,7 @@
                     </td>
                 </tr>
                 <tr th:id="'item-sched-' + ${item.id}" class="form-row" style="display:none">
-                    <td colspan="7">
+                    <td colspan="8">
                         <form method="post" th:action="@{/items/{id}/schedules(id=${item.id})}" class="inline-form">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                             <label>Type <input type="text"
@@ -210,7 +212,7 @@
                 </tr>
                 <tr th:if="${selectedItemId != null and selectedItemId.equals(item.id)}"
                     class="detail-row">
-                    <td colspan="7">
+                    <td colspan="8">
                         <div class="item-detail">
                             <div class="detail-section"
                                  th:if="${itemRecords != null and !#lists.isEmpty(itemRecords)}">

--- a/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
@@ -829,6 +829,18 @@ class ItemControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("should render purchase date column")
+    void shouldRenderPurchaseDateColumn()
+            throws Exception {
+        mockMvc.perform(get("/items")
+                        .with(user("dev").roles("USER")))
+                .andExpect(status().isOk())
+                .andExpect(content().string(
+                        containsString(
+                                "<th>Purchased</th>")));
+    }
+
+    @Test
     @DisplayName("should render category datalist")
     void shouldRenderCategoryDatalist()
             throws Exception {


### PR DESCRIPTION
## Summary
- Add "Purchased" column to the items table in `items.html` between Serial # and Actions
- Renders empty when null, uses `nowrap` class matching dashboard date style
- Updated form-row colspan values to account for new column

Closes #30

## Test plan
- [ ] CI passes
- [ ] Items list shows purchase date column
- [ ] Items without purchase date show empty cell
- [ ] Inline add/edit forms still span full table width

🤖 Generated with [Claude Code](https://claude.com/claude-code)