### PR TITLE
Validate model year bounds and reject negative costs

### DIFF
--- a/src/main/java/solutions/mystuff/domain/model/Validation.java
+++ b/src/main/java/solutions/mystuff/domain/model/Validation.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.domain.model;
 
+import java.math.BigDecimal;
 import java.util.regex.Pattern;
 
 /**
@@ -64,6 +65,33 @@ public final class Validation {
         if (value < 1) {
             throw new IllegalArgumentException(
                     fieldName + " must be at least 1");
+        }
+    }
+
+    private static final int MIN_YEAR = 1900;
+    private static final int MAX_YEAR = 2100;
+
+    /** Validates that the year is between 1900 and 2100 inclusive; null is allowed. */
+    public static void requireYearInRange(
+            Integer year, String fieldName) {
+        if (year != null
+                && (year < MIN_YEAR || year > MAX_YEAR)) {
+            throw new IllegalArgumentException(
+                    fieldName
+                            + " must be between "
+                            + MIN_YEAR + " and "
+                            + MAX_YEAR);
+        }
+    }
+
+    /** Validates that the value is not negative; null is allowed. */
+    public static void requireNonNegative(
+            BigDecimal value, String fieldName) {
+        if (value != null
+                && value.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException(
+                    fieldName
+                            + " must not be negative");
         }
     }
 }

--- a/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
@@ -102,6 +102,8 @@ public class ItemManagementService
         Validation.requireMaxLength(
                 spec.category(),
                 "Category", CATEGORY_MAX);
+        Validation.requireYearInRange(
+                spec.modelYear(), "Model year");
         return trimName;
     }
 

--- a/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
+++ b/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
@@ -56,6 +56,8 @@ public class RecordCreationService
             ServiceCompletion completion) {
         validateSummary(completion.summary());
         validateTechName(completion.techName());
+        Validation.requireNonNegative(
+                completion.cost(), "Cost");
         String serviceType = schedule != null
                 ? schedule.getServiceType() : null;
         ServiceRecord record = new ServiceRecord();

--- a/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
@@ -842,6 +842,68 @@ class ItemControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("should reject model year below 1900")
+    void shouldRejectModelYearBelowBound()
+            throws Exception {
+        mockMvc.perform(post("/items")
+                        .param("name", "Test Item")
+                        .param("modelYear", "1899")
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(model().attributeExists(
+                        "error"));
+    }
+
+    @Test
+    @DisplayName("should reject model year above 2100")
+    void shouldRejectModelYearAboveBound()
+            throws Exception {
+        mockMvc.perform(post("/items")
+                        .param("name", "Test Item")
+                        .param("modelYear", "2101")
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(model().attributeExists(
+                        "error"));
+    }
+
+    @Test
+    @DisplayName("should reject model year on update"
+            + " below 1900")
+    void shouldRejectModelYearOnUpdateBelowBound()
+            throws Exception {
+        String itemId = getFirstItemId();
+        mockMvc.perform(put("/items/" + itemId)
+                        .param("name", "Test")
+                        .param("modelYear", "1899")
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(model().attributeExists(
+                        "error"));
+    }
+
+    @Test
+    @DisplayName("should reject negative cost on"
+            + " service record")
+    void shouldRejectNegativeCostOnServiceRecord()
+            throws Exception {
+        String itemId = getFirstItemId();
+        mockMvc.perform(post("/items/" + itemId
+                        + "/service-records")
+                        .param("summary", "Test service")
+                        .param("serviceDate", "2026-04-15")
+                        .param("cost", "-1.00")
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(model().attributeExists(
+                        "error"));
+    }
+
+    @Test
     @DisplayName("should create item with all fields")
     void shouldCreateItemWithAllFields()
             throws Exception {

--- a/src/test/java/solutions/mystuff/domain/model/ValidationTest.java
+++ b/src/test/java/solutions/mystuff/domain/model/ValidationTest.java
@@ -1,0 +1,104 @@
+package solutions.mystuff.domain.model;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions
+        .assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions
+        .assertThrows;
+
+@DisplayName("Validation")
+class ValidationTest {
+
+    // --- requireYearInRange ---
+
+    @Test
+    @DisplayName("should accept null year")
+    void shouldAcceptNullYear() {
+        assertDoesNotThrow(() ->
+                Validation.requireYearInRange(
+                        null, "Model year"));
+    }
+
+    @Test
+    @DisplayName("should accept year at lower bound")
+    void shouldAcceptYearAtLowerBound() {
+        assertDoesNotThrow(() ->
+                Validation.requireYearInRange(
+                        1900, "Model year"));
+    }
+
+    @Test
+    @DisplayName("should accept year at upper bound")
+    void shouldAcceptYearAtUpperBound() {
+        assertDoesNotThrow(() ->
+                Validation.requireYearInRange(
+                        2100, "Model year"));
+    }
+
+    @Test
+    @DisplayName("should accept year in valid range")
+    void shouldAcceptYearInValidRange() {
+        assertDoesNotThrow(() ->
+                Validation.requireYearInRange(
+                        2024, "Model year"));
+    }
+
+    @Test
+    @DisplayName("should reject year below lower bound")
+    void shouldRejectYearBelowLowerBound() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Validation.requireYearInRange(
+                        1899, "Model year"));
+    }
+
+    @Test
+    @DisplayName("should reject year above upper bound")
+    void shouldRejectYearAboveUpperBound() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Validation.requireYearInRange(
+                        2101, "Model year"));
+    }
+
+    // --- requireNonNegative ---
+
+    @Test
+    @DisplayName("should accept null cost")
+    void shouldAcceptNullCost() {
+        assertDoesNotThrow(() ->
+                Validation.requireNonNegative(
+                        null, "Cost"));
+    }
+
+    @Test
+    @DisplayName("should accept zero cost")
+    void shouldAcceptZeroCost() {
+        assertDoesNotThrow(() ->
+                Validation.requireNonNegative(
+                        BigDecimal.ZERO, "Cost"));
+    }
+
+    @Test
+    @DisplayName("should accept positive cost")
+    void shouldAcceptPositiveCost() {
+        assertDoesNotThrow(() ->
+                Validation.requireNonNegative(
+                        new BigDecimal("99.99"),
+                        "Cost"));
+    }
+
+    @Test
+    @DisplayName("should reject negative cost")
+    void shouldRejectNegativeCost() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Validation.requireNonNegative(
+                        new BigDecimal("-0.01"),
+                        "Cost"));
+    }
+}

--- a/src/test/java/solutions/mystuff/domain/service/ItemManagementServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ItemManagementServiceTest.java
@@ -177,6 +177,38 @@ class ItemManagementServiceTest {
     }
 
     @Test
+    @DisplayName("should reject model year below 1900")
+    void shouldRejectModelYearBelowBound() {
+        ItemSpec spec = new ItemSpec("AC", null,
+                null, null, null, null,
+                1899, null, null, null);
+        assertThrows(IllegalArgumentException.class,
+                () -> service.createItem(orgId, spec));
+    }
+
+    @Test
+    @DisplayName("should reject model year above 2100")
+    void shouldRejectModelYearAboveBound() {
+        ItemSpec spec = new ItemSpec("AC", null,
+                null, null, null, null,
+                2101, null, null, null);
+        assertThrows(IllegalArgumentException.class,
+                () -> service.createItem(orgId, spec));
+    }
+
+    @Test
+    @DisplayName("should accept null model year")
+    void shouldAcceptNullModelYear() {
+        when(itemRepo.save(any(Item.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        ItemSpec spec = new ItemSpec("AC", null,
+                null, null, null, null,
+                null, null, null, null);
+        Item item = service.createItem(orgId, spec);
+        assertNull(item.getModelYear());
+    }
+
+    @Test
     @DisplayName("should clear fields on update when"
             + " blank")
     void shouldClearFieldsWhenBlank() {

--- a/src/test/java/solutions/mystuff/domain/service/RecordCreationServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/RecordCreationServiceTest.java
@@ -119,6 +119,53 @@ class RecordCreationServiceTest {
     }
 
     @Test
+    @DisplayName("should reject negative cost")
+    void shouldRejectNegativeCost() {
+        Item item = new Item();
+        ServiceCompletion completion =
+                new ServiceCompletion(null, "Summary",
+                        LocalDate.now(), null,
+                        new BigDecimal("-1.00"));
+        assertThatThrownBy(() ->
+                service.createRecord(orgId, item,
+                        null, completion))
+                .isInstanceOf(
+                        IllegalArgumentException.class)
+                .hasMessageContaining("negative");
+    }
+
+    @Test
+    @DisplayName("should accept null cost")
+    void shouldAcceptNullCost() {
+        Item item = new Item();
+        item.setName("Test");
+        when(repo.save(any(ServiceRecord.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        ServiceCompletion completion =
+                new ServiceCompletion(null, "Summary",
+                        LocalDate.now(), null, null);
+        service.createRecord(orgId, item,
+                null, completion);
+        verify(repo).save(any(ServiceRecord.class));
+    }
+
+    @Test
+    @DisplayName("should accept zero cost")
+    void shouldAcceptZeroCost() {
+        Item item = new Item();
+        item.setName("Test");
+        when(repo.save(any(ServiceRecord.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        ServiceCompletion completion =
+                new ServiceCompletion(null, "Summary",
+                        LocalDate.now(), null,
+                        BigDecimal.ZERO);
+        service.createRecord(orgId, item,
+                null, completion);
+        verify(repo).save(any(ServiceRecord.class));
+    }
+
+    @Test
     @DisplayName("should reject long tech name")
     void shouldRejectLongTechName() {
         Item item = new Item();


### PR DESCRIPTION
## Summary
- Add `Validation.requireYearInRange()` — rejects model years outside 1900-2100 (null allowed)
- Add `Validation.requireNonNegative()` — rejects negative costs (null allowed)
- Wire into `ItemManagementService` (create + update) and `RecordCreationService`
- 10 unit tests for Validation methods, 6 service tests, 4 integration tests

Closes #29

## Test plan
- [ ] CI passes
- [ ] Create item with model year 1899 → rejected
- [ ] Create item with model year 2101 → rejected
- [ ] Create item with null model year → accepted
- [ ] Log service record with negative cost → rejected
- [ ] Log service record with zero cost → accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)