### PR TITLE
Simplify: fix missing cost validation, add Mermaid diagrams, clean up

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/ItemController.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemController.java
@@ -12,6 +12,7 @@ import solutions.mystuff.domain.model.ItemSpec;
 import solutions.mystuff.domain.model.LogSanitizer;
 import solutions.mystuff.domain.model.NotFoundException;
 import solutions.mystuff.domain.model.PageResult;
+import solutions.mystuff.domain.model.Validation;
 import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.Vendor;
 import solutions.mystuff.domain.port.in.ItemManagement;
@@ -39,6 +40,14 @@ import org.springframework.web.bind.annotation
 
 /**
  * Handles item CRUD and service operations at /items endpoints.
+ *
+ * <div class="mermaid">
+ * sequenceDiagram
+ *     Browser->>ItemController: GET/POST/PUT/DELETE /items
+ *     ItemController->>ItemManagement: create/update/delete
+ *     ItemController->>ItemQuery: find/search/filter
+ *     ItemController-->>Browser: HTML (Thymeleaf)
+ * </div>
  *
  * @see ControllerHelper
  * @see InputValidator
@@ -496,10 +505,7 @@ public class ItemController {
     }
 
     private String normalizeCategory(String category) {
-        if (category == null || category.isBlank()) {
-            return null;
-        }
-        return category;
+        return Validation.trimOrNull(category);
     }
 
     private Item findItem(UUID itemId, UUID orgId) {

--- a/src/main/java/solutions/mystuff/domain/model/Validation.java
+++ b/src/main/java/solutions/mystuff/domain/model/Validation.java
@@ -6,6 +6,19 @@ import java.util.regex.Pattern;
 /**
  * Shared validation helpers usable by both domain services
  * and the web layer, eliminating duplicated checks.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class Validation {
+ *         +requireNotBlank(String, String) String
+ *         +requireMaxLength(String, String, int) void
+ *         +trimOrNull(String) String
+ *         +requireValidEmail(String, String) void
+ *         +requirePositive(int, String) void
+ *         +requireYearInRange(Integer, String) void
+ *         +requireNonNegative(BigDecimal, String) void
+ *     }
+ * </div>
  */
 public final class Validation {
 

--- a/src/main/java/solutions/mystuff/domain/port/in/ItemQuery.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/ItemQuery.java
@@ -12,6 +12,18 @@ import solutions.mystuff.domain.model.ServiceSchedule;
 /**
  * Inbound port for read-only item queries.
  *
+ * <div class="mermaid">
+ * classDiagram
+ *     class ItemQuery {
+ *         +findByOrganization(UUID, int, int) PageResult
+ *         +searchByOrganization(UUID, String, int, int) PageResult
+ *         +findByCategoryAndOrganization(UUID, String, int, int) PageResult
+ *         +findDistinctCategories(UUID) List~String~
+ *         +findByIdAndOrganization(UUID, UUID) Optional~Item~
+ *     }
+ *     ItemQueryService ..|> ItemQuery
+ * </div>
+ *
  * @see solutions.mystuff.domain.model.Item
  */
 public interface ItemQuery {

--- a/src/main/java/solutions/mystuff/domain/service/ItemQueryService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ItemQueryService.java
@@ -19,6 +19,14 @@ import org.springframework.stereotype.Service;
 /**
  * Delegates item read queries to outbound repository ports.
  *
+ * <div class="mermaid">
+ * sequenceDiagram
+ *     Controller->>ItemQueryService: findByOrganization
+ *     ItemQueryService->>ItemRepository: findByOrganizationId
+ *     ItemRepository-->>ItemQueryService: PageResult
+ *     ItemQueryService-->>Controller: PageResult
+ * </div>
+ *
  * @see ItemQuery
  */
 @Service

--- a/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
+++ b/src/main/java/solutions/mystuff/domain/service/RecordCreationService.java
@@ -96,6 +96,7 @@ public class RecordCreationService
             String techName, BigDecimal cost) {
         validateSummary(summary);
         validateTechName(techName);
+        Validation.requireNonNegative(cost, "Cost");
         ServiceRecord record =
                 requireRecord(orgId, recordId);
         record.setSummary(summary.trim());

--- a/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
@@ -924,6 +924,7 @@ class ItemControllerIntegrationTest {
         assertTrue(
                 html.contains("name=\"category\""),
                 "should have category select");
+    }
 
     @Test
     @DisplayName("should delete item")


### PR DESCRIPTION
## Summary
- Fix bug: `updateRecord` was missing `requireNonNegative` cost validation (negative costs could be submitted via edit form)
- Replace `normalizeCategory` with `Validation.trimOrNull` (eliminates duplicate null/blank check)
- Add Mermaid diagrams to `ItemQuery`, `ItemQueryService`, `ItemController`, and `Validation` per ADR-0022
- Fix missing closing brace in `shouldRenderCategoryDropdown` test (from conflict resolution)

## Test plan
- [ ] CI passes (compilation, checkstyle, tests, coverage)
- [ ] Editing a service record with negative cost is rejected
- [ ] Category filtering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)