### PR TITLE
Add composite index on (organization_id, category) for items

### DIFF
--- a/src/main/resources/db/migration/V14__add_category_index.sql
+++ b/src/main/resources/db/migration/V14__add_category_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_items_org_category ON items(organization_id, category);


### PR DESCRIPTION
## Summary
- Add Flyway migration `V14__add_category_index.sql` with composite index `idx_items_org_category` on `items(organization_id, category)`
- Benefits `findDistinctCategoriesByOrganizationId`, `findByCategoryAndOrganizationId`, and `searchByCategoryAndOrganizationId` queries

Closes #37

## Test plan
- [ ] CI passes
- [ ] Flyway migration applies cleanly
- [ ] Category filtering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)