### PR TITLE
Add category filtering to REST API

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/api/ItemApiController.java
+++ b/src/main/java/solutions/mystuff/application/web/api/ItemApiController.java
@@ -13,6 +13,7 @@ import solutions.mystuff.domain.port.in.ItemQuery;
 import solutions.mystuff.domain.port.in.UserResolver;
 import solutions.mystuff.application.web.LinkHeaderBuilder;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
@@ -35,6 +36,9 @@ import org.springframework.web.bind.annotation.RestController;
  *     Client->>ItemApiController: GET /api/v1/items
  *     ItemApiController->>UserResolver: resolveOrCreate
  *     ItemApiController->>ItemQuery: findByOrganization
+ *     ItemApiController-->>Client: JSON PageResponse
+ *     Client->>ItemApiController: GET /api/v1/items?category=HVAC
+ *     ItemApiController->>ItemQuery: findByCategoryAndOrganization
  *     ItemApiController-->>Client: JSON PageResponse
  * </div>
  *
@@ -67,23 +71,54 @@ public class ItemApiController {
     public PageResponse<ItemResponse> list(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
+            @Parameter(description = "Search query")
             @RequestParam(required = false) String q,
+            @Parameter(description = "Category filter")
+            @RequestParam(required = false)
+                    String category,
             Principal principal,
             HttpServletResponse response) {
         UUID orgId = resolveOrgId(principal);
         int clamped = Math.max(1,
                 Math.min(size, 100));
-        PageResult<Item> result = q != null
-                && !q.isBlank()
-                ? itemQuery.searchByOrganization(
-                        orgId, q, page, clamped)
-                : itemQuery.findByOrganization(
-                        orgId, page, clamped);
+        String cat = normalizeCategory(category);
+        PageResult<Item> result = queryItems(
+                q, cat, orgId, page, clamped);
         LinkHeaderBuilder.addLinkHeader(
                 response, "/api/v1/items",
-                result, q);
+                result, q, cat);
         return PageResponse.from(
                 result, ItemResponse::from);
+    }
+
+    private PageResult<Item> queryItems(
+            String q, String category,
+            UUID orgId, int page, int size) {
+        boolean hasQuery = q != null && !q.isBlank();
+        boolean hasCat = category != null;
+        if (hasQuery && hasCat) {
+            return itemQuery
+                    .searchByCategoryAndOrganization(
+                            orgId, q, category,
+                            page, size);
+        } else if (hasQuery) {
+            return itemQuery.searchByOrganization(
+                    orgId, q, page, size);
+        } else if (hasCat) {
+            return itemQuery
+                    .findByCategoryAndOrganization(
+                            orgId, category, page, size);
+        } else {
+            return itemQuery.findByOrganization(
+                    orgId, page, size);
+        }
+    }
+
+    private String normalizeCategory(String category) {
+        if (category == null || category.isBlank()) {
+            return null;
+        }
+        return category;
     }
 
     /** Gets a single item by ID. */

--- a/src/test/java/solutions/mystuff/application/web/api/RestApiIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/api/RestApiIntegrationTest.java
@@ -11,7 +11,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet
         .request.MockMvcRequestBuilders.delete;
@@ -201,6 +203,77 @@ class RestApiIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content",
                         notNullValue()));
+    }
+
+    @Test
+    @DisplayName("should filter items by category")
+    void shouldFilterItemsByCategory()
+            throws Exception {
+        mockMvc.perform(post("/api/v1/items")
+                        .header("Authorization",
+                                "Bearer " + token)
+                        .contentType(
+                                MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Cat Filter"
+                                + " Item\","
+                                + "\"category\":\"HVAC\"}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/items")
+                        .param("category", "HVAC")
+                        .header("Authorization",
+                                "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content",
+                        notNullValue()))
+                .andExpect(jsonPath(
+                        "$.content[*].category",
+                        everyItem(is("HVAC"))));
+    }
+
+    @Test
+    @DisplayName(
+            "should filter by category and search")
+    void shouldFilterByCategoryAndSearch()
+            throws Exception {
+        mockMvc.perform(post("/api/v1/items")
+                        .header("Authorization",
+                                "Bearer " + token)
+                        .contentType(
+                                MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Searchable"
+                                + " HVAC Unit\","
+                                + "\"category\":\"HVAC\"}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/items")
+                        .param("category", "HVAC")
+                        .param("q", "Searchable")
+                        .header("Authorization",
+                                "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content",
+                        notNullValue()))
+                .andExpect(jsonPath(
+                        "$.content[*].category",
+                        everyItem(is("HVAC"))));
+    }
+
+    @Test
+    @DisplayName(
+            "should ignore blank category parameter")
+    void shouldIgnoreBlankCategory()
+            throws Exception {
+        mockMvc.perform(get("/api/v1/items")
+                        .param("category", "  ")
+                        .header("Authorization",
+                                "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content",
+                        notNullValue()))
+                .andExpect(jsonPath(
+                        "$.content.length()",
+                        greaterThan(0)));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add optional `category` query parameter to `GET /api/v1/items` in `ItemApiController`
- Reuses existing `ItemQuery` port methods with same 4-way branching as web controller
- OpenAPI `@Parameter` annotation for Swagger docs
- 3 integration tests: filter by category, category + search, blank category ignored

Closes #39

## Test plan
- [ ] CI passes
- [ ] `GET /api/v1/items?category=HVAC` filters items
- [ ] `GET /api/v1/items?q=test&category=HVAC` combines filters
- [ ] `GET /api/v1/items?category=` returns all items

🤖 Generated with [Claude Code](https://claude.com/claude-code)