### PR TITLE
Fix item deletion cascade efficiency

### DIFF
--- a/src/main/java/solutions/mystuff/infrastructure/persistence/JpaItemRepositoryAdapter.java
+++ b/src/main/java/solutions/mystuff/infrastructure/persistence/JpaItemRepositoryAdapter.java
@@ -132,7 +132,11 @@ public class JpaItemRepositoryAdapter
         return delegate.save(item);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * Deletes an item via bulk JPQL, bypassing Hibernate
+     * entity-level cascade. The database {@code ON DELETE CASCADE}
+     * removes child schedules and records in a single statement.
+     */
     @Override
     public void deleteByIdAndOrganizationId(
             UUID id, UUID organizationId) {

--- a/src/main/java/solutions/mystuff/infrastructure/persistence/SpringDataItemRepository.java
+++ b/src/main/java/solutions/mystuff/infrastructure/persistence/SpringDataItemRepository.java
@@ -8,8 +8,10 @@ import solutions.mystuff.domain.model.Item;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Internal Spring Data repository for {@link Item} persistence.
@@ -87,7 +89,21 @@ interface SpringDataItemRepository
             @Param("cat") String category,
             Pageable pageable);
 
+    /**
+     * Bulk-deletes an item by ID and organization using JPQL
+     * instead of entity removal. This avoids Hibernate loading
+     * and individually deleting each child schedule and record,
+     * relying on the database {@code ON DELETE CASCADE} on
+     * {@code service_schedules.item_id} and
+     * {@code service_records.item_id} instead.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Item i "
+            + "WHERE i.id = :id "
+            + "AND i.organizationId = :orgId")
     void deleteByIdAndOrganizationId(
-            UUID id, UUID organizationId);
+            @Param("id") UUID id,
+            @Param("orgId") UUID organizationId);
 
 }


### PR DESCRIPTION
## Summary
- Replace derived `deleteByIdAndOrganizationId` with `@Modifying @Query` bulk JPQL delete
- Database `ON DELETE CASCADE` handles child schedules/records in a single operation
- Eliminates N+M+4 query overhead from JPA cascade loading and individual deletes
- Preserves `CascadeType.ALL` + `orphanRemoval` for persist/merge operations

Closes #40

## Test plan
- [ ] CI passes
- [ ] Deleting an item with schedules and records works correctly
- [ ] Existing delete tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)