### PR TITLE
Fix SpEL 'or' operator on non-boolean variables in items template

### DIFF
--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -27,7 +27,7 @@
                     <svg th:replace="~{fragments/icons :: icon-search}"></svg>
                     Search
                 </button>
-                <a th:if="${q or selectedCategory}" th:href="@{/items}"
+                <a th:if="${q != null or selectedCategory != null}" th:href="@{/items}"
                    class="btn-icon btn-cancel" title="Clear filters">
                     <svg th:replace="~{fragments/icons :: icon-cancel}"></svg>
                 </a>


### PR DESCRIPTION
th:if="${q or selectedCategory}" throws TemplateProcessingException because SpEL 'or' requires boolean operands but q is a String. Changed to ${q != null or selectedCategory != null}.