### PR TITLE
Simplify service due report: show all overdue, remove start date

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/ReportController.java
+++ b/src/main/java/solutions/mystuff/application/web/ReportController.java
@@ -88,8 +88,6 @@ public class ReportController {
         model.addAttribute("items",
                 itemQuery.findAllByOrganization(
                         orgId));
-        model.addAttribute("defaultStart",
-                LocalDate.now());
         model.addAttribute("defaultEnd",
                 dueSoonCutoff());
         addCostSummary(orgId, model);
@@ -98,8 +96,8 @@ public class ReportController {
 
     @Operation(summary = "Service summary PDF",
             description = "Streams a PDF listing all"
-                    + " schedules due by end of the"
-                    + " current or next month."
+                    + " schedules due through a given"
+                    + " date (defaults to end of month)."
                     + " Includes item name, service"
                     + " type, vendor, due date, and"
                     + " last completed date.",
@@ -112,10 +110,6 @@ public class ReportController {
                                     + "/pdf")))
     @GetMapping("/reports/service-summary")
     public void serviceSummary(
-            @Parameter(description = "Start of date range"
-                    + " (inclusive, defaults to today)")
-            @RequestParam(required = false)
-            LocalDate startDate,
             @Parameter(description = "End of date range"
                     + " (inclusive, defaults to"
                     + " end-of-month cutoff)")
@@ -133,16 +127,14 @@ public class ReportController {
         }
         helper.setOrgMdc(user);
         UUID orgId = user.getOrganization().getId();
-        LocalDate start = startDate != null
-                ? startDate : LocalDate.now();
         LocalDate end = endDate != null
                 ? endDate : dueSoonCutoff();
         List<ServiceSchedule> schedules =
-                filterByDateRange(orgId, start, end);
+                filterDueThrough(orgId, end);
         String orgName = user.getOrganization()
                 .getName();
         ServiceSummaryPdf.write(
-                response, schedules, start, end,
+                response, schedules, end,
                 orgName, user.getUsername());
     }
 
@@ -207,16 +199,13 @@ public class ReportController {
                 user.getUsername());
     }
 
-    private List<ServiceSchedule> filterByDateRange(
-            UUID orgId, LocalDate start,
-            LocalDate end) {
+    private List<ServiceSchedule> filterDueThrough(
+            UUID orgId, LocalDate end) {
         return scheduleQuery
                 .findAllActiveByOrganization(orgId)
                 .stream()
                 .filter(s ->
                         s.getNextDueDate() != null
-                        && !s.getNextDueDate()
-                                .isBefore(start)
                         && !s.getNextDueDate()
                                 .isAfter(end))
                 .toList();

--- a/src/main/java/solutions/mystuff/application/web/ServiceSummaryPdf.java
+++ b/src/main/java/solutions/mystuff/application/web/ServiceSummaryPdf.java
@@ -31,7 +31,7 @@ final class ServiceSummaryPdf {
     static void write(
             HttpServletResponse response,
             List<ServiceSchedule> schedules,
-            LocalDate startDate, LocalDate endDate,
+            LocalDate endDate,
             String orgName,
             String username) throws Exception {
         response.setContentType("application/pdf");
@@ -43,7 +43,7 @@ final class ServiceSummaryPdf {
                 response.getOutputStream());
         doc.open();
         PdfHelper.addOrgHeader(doc, orgName, username);
-        addTitle(doc, orgName, startDate, endDate);
+        addTitle(doc, orgName, endDate);
         if (schedules.isEmpty()) {
             doc.add(new Paragraph(
                     "No service due.",
@@ -59,12 +59,9 @@ final class ServiceSummaryPdf {
 
     private static void addTitle(
             Document doc, String orgName,
-            LocalDate startDate,
             LocalDate endDate) throws Exception {
         Paragraph title = new Paragraph(
-                orgName + " — Service Due: "
-                        + startDate.format(PdfHelper.FMT)
-                        + " – "
+                orgName + " — Service Due Through "
                         + endDate.format(PdfHelper.FMT),
                 PdfHelper.TITLE_FONT);
         title.setAlignment(Element.ALIGN_CENTER);

--- a/src/main/resources/templates/reports.html
+++ b/src/main/resources/templates/reports.html
@@ -23,18 +23,13 @@
                 <tbody>
                 <tr>
                     <td>Service Due Soon</td>
-                    <td>Schedules due within a
-                        date range</td>
+                    <td>All schedules due through
+                        a given date</td>
                     <td>
                         <form class="inline-form"
                               action="/reports/service-summary"
                               method="get" target="_blank">
-                            <label>From
-                                <input type="date"
-                                       name="startDate"
-                                       th:value="${defaultStart}"/>
-                            </label>
-                            <label>To
+                            <label>Through
                                 <input type="date"
                                        name="endDate"
                                        th:value="${defaultEnd}"/>

--- a/src/test/java/solutions/mystuff/application/web/ReportControllerIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/ReportControllerIntegrationTest.java
@@ -108,13 +108,11 @@ class ReportControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("should generate PDF with custom date range")
-    void shouldGeneratePdfWithCustomDateRange()
+    @DisplayName("should generate PDF with custom end date")
+    void shouldGeneratePdfWithCustomEndDate()
             throws Exception {
         mockMvc.perform(
                         get("/reports/service-summary")
-                                .param("startDate",
-                                        "2020-01-01")
                                 .param("endDate",
                                         "2030-12-31")
                                 .with(user("dev")
@@ -125,14 +123,13 @@ class ReportControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("should include default dates on reports page")
-    void shouldIncludeDefaultDatesOnReportsPage()
+    @DisplayName("should include default end date"
+            + " on reports page")
+    void shouldIncludeDefaultEndDateOnReportsPage()
             throws Exception {
         mockMvc.perform(get("/reports")
                         .with(user("dev").roles("USER")))
                 .andExpect(status().isOk())
-                .andExpect(model().attributeExists(
-                        "defaultStart"))
                 .andExpect(model().attributeExists(
                         "defaultEnd"));
     }


### PR DESCRIPTION
## Summary
- Remove `startDate` parameter — report now includes all schedules due through the end date, including overdue items from the past
- Previously the start date defaulted to today, which excluded overdue schedules (the most important ones to see)
- Template simplified from "From/To" date pickers to single "Through" date picker
- PDF title changed from "Service Due: {start} – {end}" to "Service Due Through {end}"
- Default end date unchanged (end of current or next month)

## Test plan
- [ ] CI passes
- [ ] Generate PDF with default date — includes overdue schedules
- [ ] Generate PDF with custom end date — works correctly
- [ ] Reports page shows single date picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)