### PR TITLE
Add mobile responsive design

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -558,3 +558,155 @@ a.btn-icon:hover {
 .recent-activity { margin-top: 1rem; }
 
 .nowrap { white-space: nowrap; }
+
+/* --- Table scroll wrapper (added by template or CSS) --- */
+.table-scroll-wrapper {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+/* --- Touch device: make action buttons always visible --- */
+@media (hover: none), (pointer: coarse) {
+    td.actions .btn-icon {
+        opacity: 1;
+    }
+}
+
+/* --- Tablet breakpoint: 768px --- */
+@media (max-width: 768px) {
+    body {
+        padding: 0.5rem;
+    }
+
+    header {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    header nav {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.25rem;
+    }
+
+    header h1 {
+        font-size: 1.3rem;
+    }
+
+    .inline-form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .inline-form label {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.15rem;
+    }
+
+    .inline-form input,
+    .inline-form select {
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .inline-form button {
+        align-self: flex-start;
+    }
+
+    #search form {
+        flex-wrap: wrap;
+    }
+
+    #search input,
+    #search select {
+        flex: 1 1 100%;
+    }
+
+    .section-header {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .dashboard-stats {
+        gap: 0.5rem;
+    }
+
+    .stat-card {
+        min-width: 100px;
+        padding: 1rem;
+    }
+
+    .stat-card .stat-number {
+        font-size: 2rem;
+    }
+
+    .dashboard-links {
+        flex-wrap: wrap;
+    }
+
+    th, td {
+        padding: 0.5rem 0.6rem;
+        font-size: 0.85rem;
+    }
+
+    .vendor-form label {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .settings-section {
+        padding: 0.75rem 1rem;
+    }
+}
+
+/* --- Phone breakpoint: 480px --- */
+@media (max-width: 480px) {
+    body {
+        padding: 0.25rem;
+    }
+
+    header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    header nav {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .user-info {
+        flex-direction: row;
+        font-size: 0.75rem;
+    }
+
+    .stat-card {
+        min-width: 80px;
+        padding: 0.75rem;
+    }
+
+    .stat-card .stat-number {
+        font-size: 1.5rem;
+    }
+
+    .stat-card .stat-label {
+        font-size: 0.75rem;
+    }
+
+    th, td {
+        padding: 0.4rem 0.5rem;
+        font-size: 0.8rem;
+    }
+
+    .add-form {
+        padding: 0.5rem;
+    }
+
+    .pagination {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        font-size: 0.8rem;
+    }
+}

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -38,6 +38,7 @@
         <section class="recent-activity">
             <h2>Recent Activity</h2>
             <p th:if="${#lists.isEmpty(recentRecords)}">No service records yet.</p>
+            <div class="table-scroll-wrapper">
             <table th:unless="${#lists.isEmpty(recentRecords)}">
                 <thead>
                 <tr>
@@ -56,6 +57,7 @@
                 </tr>
                 </tbody>
             </table>
+            </div>
         </section>
     </div>
 </main>

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -85,6 +85,7 @@
                 </form>
             </div>
             <p th:if="${#lists.isEmpty(items)}">No items found.</p>
+            <div class="table-scroll-wrapper">
             <table th:unless="${#lists.isEmpty(items)}">
                 <thead>
                 <tr>
@@ -419,6 +420,7 @@
                 </th:block>
                 </tbody>
             </table>
+            </div>
             <nav th:if="${itemPage != null and (itemPage.hasPrevious() or itemPage.hasNext())}" class="pagination">
                 <a th:if="${itemPage.hasPrevious()}"
                    th:href="@{/items(page=${itemPage.page() - 1},size=${itemPage.size()},q=${q},category=${selectedCategory})}">Prev</a>

--- a/src/main/resources/templates/schedules.html
+++ b/src/main/resources/templates/schedules.html
@@ -16,6 +16,7 @@
         <section id="schedules">
             <h2>Upcoming Service</h2>
             <p th:if="${#lists.isEmpty(schedules)}">No upcoming service.</p>
+            <div class="table-scroll-wrapper">
             <table th:unless="${#lists.isEmpty(schedules)}">
                 <thead>
                 <tr>
@@ -131,6 +132,7 @@
                 </th:block>
                 </tbody>
             </table>
+            </div>
             <nav th:if="${schedPage != null and (schedPage.hasPrevious() or schedPage.hasNext())}" class="pagination">
                 <a th:if="${schedPage.hasPrevious()}"
                    th:href="@{/schedules(page=${schedPage.page() - 1},size=${schedPage.size()})}">Prev</a>

--- a/src/main/resources/templates/vendors.html
+++ b/src/main/resources/templates/vendors.html
@@ -85,6 +85,7 @@
         </form>
     </div>
 
+    <div class="table-scroll-wrapper">
     <table th:unless="${noOrganization}" class="data-table">
         <thead>
         <tr>
@@ -215,6 +216,7 @@
         </th:block>
         </tbody>
     </table>
+    </div>
 </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add media queries for 768px and 480px breakpoints
- Tables wrapped in `.table-scroll-wrapper` for horizontal scrolling on mobile
- Inline forms stack vertically on small screens with full-width inputs
- Action buttons always visible on touch devices via `@media (hover: none)`
- Header navigation wraps/stacks gracefully on small screens
- Dashboard stats and links wrap on mobile
- All existing desktop styling preserved

Closes #48

## Test plan
- [ ] CI passes
- [ ] Desktop layout unchanged
- [ ] Resize browser to 768px — forms stack, tables scroll, header wraps
- [ ] Resize to 480px — header stacks vertically, tighter padding
- [ ] Test on mobile/touch — action buttons visible without hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)