### PR TITLE
Fix CI: update test for renamed Clear filters button

### DIFF
--- a/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
@@ -163,7 +163,7 @@ class ItemControllerIntegrationTest {
         String html = result.getResponse()
                 .getContentAsString();
         assertTrue(
-                html.contains("Clear search"),
+                html.contains("Clear filters"),
                 "should show clear search button");
     }
 
@@ -177,7 +177,7 @@ class ItemControllerIntegrationTest {
         String html = result.getResponse()
                 .getContentAsString();
         assertTrue(
-                !html.contains("Clear search"),
+                !html.contains("Clear filters"),
                 "should not show clear search button");
     }
 


### PR DESCRIPTION
## Summary
- Fix `shouldShowSearchCancel` and `shouldHideSearchCancel` tests
- Button title was changed from "Clear search" to "Clear filters" when category filtering was added (#28) but these tests weren't updated

## Test plan
- [ ] CI passes — this is the fix for the failing test

🤖 Generated with [Claude Code](https://claude.com/claude-code)