### PR TITLE
Extract domain PageRequest record to reduce parameter sprawl

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/ItemController.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemController.java
@@ -11,6 +11,7 @@ import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.ItemSpec;
 import solutions.mystuff.domain.model.LogSanitizer;
 import solutions.mystuff.domain.model.NotFoundException;
+import solutions.mystuff.domain.model.PageRequest;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.Validation;
 import solutions.mystuff.domain.model.ServiceCompletion;
@@ -138,8 +139,10 @@ public class ItemController {
         }
         helper.setOrgMdc(user);
         UUID orgId = user.getOrganization().getId();
-        loadItems(q, category, orgId, page, size,
-                sort, dir, model, response);
+        PageRequest pageReq = new PageRequest(
+                page, size, sort, dir);
+        loadItems(q, category, orgId, pageReq,
+                model, response);
         helper.addUserAttrs(user, model);
         return "items";
     }
@@ -170,8 +173,9 @@ public class ItemController {
         }
         helper.setOrgMdc(user);
         UUID orgId = user.getOrganization().getId();
-        loadItems(null, null, orgId, page, size,
-                "name", "asc", model, response);
+        loadItems(null, null, orgId,
+                new PageRequest(page, size),
+                model, response);
         helper.addUserAttrs(user, model);
         addDetailAttrs(model, itemId, orgId);
         return "items";
@@ -479,15 +483,16 @@ public class ItemController {
 
     private void loadItems(
             String q, String category,
-            UUID orgId, int page, int size,
-            String sort, String dir,
+            UUID orgId, PageRequest pageReq,
             Model model, HttpServletResponse response) {
-        int safeSize = helper.clampSize(size);
-        int safePage = Math.max(0, page);
+        int safeSize = helper.clampSize(pageReq.size());
+        int safePage = Math.max(0, pageReq.page());
         String cat = normalizeCategory(category);
+        PageRequest safe = new PageRequest(
+                safePage, safeSize,
+                pageReq.sort(), pageReq.dir());
         PageResult<Item> result = queryItems(
-                q, cat, orgId, safePage, safeSize,
-                sort, dir);
+                q, cat, orgId, safe);
         if (q != null && !q.isBlank()) {
             model.addAttribute("q", q);
         }
@@ -508,8 +513,7 @@ public class ItemController {
 
     private PageResult<Item> queryItems(
             String q, String category,
-            UUID orgId, int page, int size,
-            String sort, String dir) {
+            UUID orgId, PageRequest pageReq) {
         boolean hasQuery = q != null && !q.isBlank();
         boolean hasCat = category != null;
         if (hasQuery && hasCat) {
@@ -519,23 +523,23 @@ public class ItemController {
             return itemQuery
                     .searchByCategoryAndOrganization(
                             orgId, q, category,
-                            page, size, sort, dir);
+                            pageReq);
         } else if (hasQuery) {
             log.info("Searching items query={}",
                     LogSanitizer.sanitize(q));
             return itemQuery.searchByOrganization(
-                    orgId, q, page, size, sort, dir);
+                    orgId, q, pageReq);
         } else if (hasCat) {
             log.info("Listing items cat={}",
                     LogSanitizer.sanitize(category));
             return itemQuery
                     .findByCategoryAndOrganization(
-                            orgId, category, page, size,
-                            sort, dir);
+                            orgId, category, pageReq);
         } else {
-            log.info("Listing items page={}", page);
+            log.info("Listing items page={}",
+                    pageReq.page());
             return itemQuery.findByOrganization(
-                    orgId, page, size, sort, dir);
+                    orgId, pageReq);
         }
     }
 

--- a/src/main/java/solutions/mystuff/application/web/api/ItemApiController.java
+++ b/src/main/java/solutions/mystuff/application/web/api/ItemApiController.java
@@ -7,6 +7,7 @@ import solutions.mystuff.domain.model.AppUser;
 import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.ItemSpec;
 import solutions.mystuff.domain.model.NotFoundException;
+import solutions.mystuff.domain.model.PageRequest;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.Validation;
 import solutions.mystuff.domain.port.in.ItemManagement;
@@ -83,8 +84,10 @@ public class ItemApiController {
         int clamped = Math.max(1,
                 Math.min(size, 100));
         String cat = normalizeCategory(category);
+        PageRequest pageReq = new PageRequest(
+                page, clamped);
         PageResult<Item> result = queryItems(
-                q, cat, orgId, page, clamped);
+                q, cat, orgId, pageReq);
         LinkHeaderBuilder.addLinkHeader(
                 response, "/api/v1/items",
                 result, q, cat);
@@ -94,26 +97,24 @@ public class ItemApiController {
 
     private PageResult<Item> queryItems(
             String q, String category,
-            UUID orgId, int page, int size) {
+            UUID orgId, PageRequest pageReq) {
         boolean hasQuery = q != null && !q.isBlank();
         boolean hasCat = category != null;
         if (hasQuery && hasCat) {
             return itemQuery
                     .searchByCategoryAndOrganization(
                             orgId, q, category,
-                            page, size, "name", "asc");
+                            pageReq);
         } else if (hasQuery) {
             return itemQuery.searchByOrganization(
-                    orgId, q, page, size,
-                    "name", "asc");
+                    orgId, q, pageReq);
         } else if (hasCat) {
             return itemQuery
                     .findByCategoryAndOrganization(
-                            orgId, category, page, size,
-                            "name", "asc");
+                            orgId, category, pageReq);
         } else {
             return itemQuery.findByOrganization(
-                    orgId, page, size, "name", "asc");
+                    orgId, pageReq);
         }
     }
 

--- a/src/main/java/solutions/mystuff/domain/model/PageRequest.java
+++ b/src/main/java/solutions/mystuff/domain/model/PageRequest.java
@@ -1,0 +1,48 @@
+package solutions.mystuff.domain.model;
+
+/**
+ * Domain-level pagination parameters.
+ *
+ * <p>Bundles page index, page size, sort field, and sort
+ * direction into a single value object, replacing the
+ * trailing {@code int page, int size, String sort,
+ * String dir} parameter lists on paginated query methods.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class PageRequest {
+ *         +int page
+ *         +int size
+ *         +String sort
+ *         +String dir
+ *     }
+ *     PageRequest ..> PageResult : used by queries
+ * </div>
+ *
+ * @param page zero-based page index
+ * @param size number of items per page
+ * @param sort field to sort by (e.g. "name")
+ * @param dir  sort direction ("asc" or "desc")
+ */
+public record PageRequest(
+        int page,
+        int size,
+        String sort,
+        String dir) {
+
+    /** Default sort field. */
+    public static final String DEFAULT_SORT = "name";
+
+    /** Default sort direction. */
+    public static final String DEFAULT_DIR = "asc";
+
+    /**
+     * Creates a page request with default sort.
+     *
+     * @param page zero-based page index
+     * @param size number of items per page
+     */
+    public PageRequest(int page, int size) {
+        this(page, size, DEFAULT_SORT, DEFAULT_DIR);
+    }
+}

--- a/src/main/java/solutions/mystuff/domain/port/in/ItemQuery.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/ItemQuery.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.PageRequest;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.ServiceRecord;
 import solutions.mystuff.domain.model.ServiceSchedule;
@@ -15,9 +16,9 @@ import solutions.mystuff.domain.model.ServiceSchedule;
  * <div class="mermaid">
  * classDiagram
  *     class ItemQuery {
- *         +findByOrganization(UUID, int, int, String, String) PageResult
- *         +searchByOrganization(UUID, String, int, int, String, String) PageResult
- *         +findByCategoryAndOrganization(UUID, String, int, int, String, String) PageResult
+ *         +findByOrganization(UUID, PageRequest) PageResult
+ *         +searchByOrganization(UUID, String, PageRequest) PageResult
+ *         +findByCategoryAndOrganization(UUID, String, PageRequest) PageResult
  *         +findDistinctCategories(UUID) List~String~
  *         +findByIdAndOrganization(UUID, UUID) Optional~Item~
  *     }
@@ -30,23 +31,22 @@ public interface ItemQuery {
 
     /** Find a page of items for an organization. */
     PageResult<Item> findByOrganization(
-            UUID orgId, int page, int size,
-            String sort, String dir);
+            UUID orgId, PageRequest pageReq);
 
     /** Search items by query with pagination. */
     PageResult<Item> searchByOrganization(
-            UUID orgId, String query, int page, int size,
-            String sort, String dir);
+            UUID orgId, String query,
+            PageRequest pageReq);
 
     /** Find a page of items filtered by category. */
     PageResult<Item> findByCategoryAndOrganization(
             UUID orgId, String category,
-            int page, int size, String sort, String dir);
+            PageRequest pageReq);
 
     /** Search items by query and category. */
     PageResult<Item> searchByCategoryAndOrganization(
             UUID orgId, String query, String category,
-            int page, int size, String sort, String dir);
+            PageRequest pageReq);
 
     /** Find distinct categories for an organization. */
     List<String> findDistinctCategories(UUID orgId);

--- a/src/main/java/solutions/mystuff/domain/port/out/ItemRepository.java
+++ b/src/main/java/solutions/mystuff/domain/port/out/ItemRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.PageRequest;
 import solutions.mystuff.domain.model.PageResult;
 
 /**
@@ -14,14 +15,14 @@ import solutions.mystuff.domain.model.PageResult;
  * classDiagram
  *     class ItemRepository {
  *         +findByOrganizationId(UUID) List~Item~
- *         +findByOrganizationId(UUID, int, int, String, String) PageResult~Item~
+ *         +findByOrganizationId(UUID, PageRequest) PageResult~Item~
  *         +searchByOrganizationId(UUID, String) List~Item~
- *         +searchByOrganizationId(UUID, String, int, int, String, String) PageResult~Item~
+ *         +searchByOrganizationId(UUID, String, PageRequest) PageResult~Item~
  *         +findByIdAndOrganizationId(UUID, UUID) Optional~Item~
  *         +countByOrganizationId(UUID) long
  *         +findDistinctCategoriesByOrganizationId(UUID) List~String~
- *         +findByCategoryAndOrganizationId(UUID, String, int, int, String, String) PageResult~Item~
- *         +searchByCategoryAndOrganizationId(UUID, String, String, int, int, String, String) PageResult~Item~
+ *         +findByCategoryAndOrganizationId(UUID, String, PageRequest) PageResult~Item~
+ *         +searchByCategoryAndOrganizationId(UUID, String, String, PageRequest) PageResult~Item~
  *         +save(Item) Item
  *         +deleteByIdAndOrganizationId(UUID, UUID) void
  *     }
@@ -37,8 +38,7 @@ public interface ItemRepository {
 
     /** Find a page of items belonging to an organization. */
     PageResult<Item> findByOrganizationId(
-            UUID organizationId, int page, int size,
-            String sort, String dir);
+            UUID organizationId, PageRequest pageReq);
 
     /** Search items by query within an organization. */
     List<Item> searchByOrganizationId(
@@ -47,7 +47,7 @@ public interface ItemRepository {
     /** Search items by query with pagination. */
     PageResult<Item> searchByOrganizationId(
             UUID organizationId, String query,
-            int page, int size, String sort, String dir);
+            PageRequest pageReq);
 
     /** Find a single item by ID scoped to an organization. */
     Optional<Item> findByIdAndOrganizationId(
@@ -63,13 +63,12 @@ public interface ItemRepository {
     /** Find a page of items filtered by category. */
     PageResult<Item> findByCategoryAndOrganizationId(
             UUID organizationId, String category,
-            int page, int size, String sort, String dir);
+            PageRequest pageReq);
 
     /** Search items by query and category with pagination. */
     PageResult<Item> searchByCategoryAndOrganizationId(
             UUID organizationId, String query,
-            String category, int page, int size,
-            String sort, String dir);
+            String category, PageRequest pageReq);
 
     /** Persist a new or updated item. */
     Item save(Item item);

--- a/src/main/java/solutions/mystuff/domain/service/ItemQueryService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ItemQueryService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.PageRequest;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.ServiceRecord;
 import solutions.mystuff.domain.model.ServiceSchedule;
@@ -48,20 +49,18 @@ public class ItemQueryService implements ItemQuery {
     /** {@inheritDoc} */
     @Override
     public PageResult<Item> findByOrganization(
-            UUID orgId, int page, int size,
-            String sort, String dir) {
+            UUID orgId, PageRequest pageReq) {
         return itemRepo.findByOrganizationId(
-                orgId, page, size, sort, dir);
+                orgId, pageReq);
     }
 
     /** {@inheritDoc} */
     @Override
     public PageResult<Item> searchByOrganization(
             UUID orgId, String query,
-            int page, int size,
-            String sort, String dir) {
+            PageRequest pageReq) {
         return itemRepo.searchByOrganizationId(
-                orgId, query, page, size, sort, dir);
+                orgId, query, pageReq);
     }
 
     /** {@inheritDoc} */
@@ -69,12 +68,10 @@ public class ItemQueryService implements ItemQuery {
     public PageResult<Item>
             findByCategoryAndOrganization(
                     UUID orgId, String category,
-                    int page, int size,
-                    String sort, String dir) {
+                    PageRequest pageReq) {
         return itemRepo
                 .findByCategoryAndOrganizationId(
-                        orgId, category, page, size,
-                        sort, dir);
+                        orgId, category, pageReq);
     }
 
     /** {@inheritDoc} */
@@ -83,12 +80,11 @@ public class ItemQueryService implements ItemQuery {
             searchByCategoryAndOrganization(
                     UUID orgId, String query,
                     String category,
-                    int page, int size,
-                    String sort, String dir) {
+                    PageRequest pageReq) {
         return itemRepo
                 .searchByCategoryAndOrganizationId(
                         orgId, query, category,
-                        page, size, sort, dir);
+                        pageReq);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/solutions/mystuff/infrastructure/persistence/JpaItemRepositoryAdapter.java
+++ b/src/main/java/solutions/mystuff/infrastructure/persistence/JpaItemRepositoryAdapter.java
@@ -6,9 +6,9 @@ import java.util.Set;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.PageRequest;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.port.out.ItemRepository;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
@@ -51,11 +51,10 @@ public class JpaItemRepositoryAdapter
     /** {@inheritDoc} */
     @Override
     public PageResult<Item> findByOrganizationId(
-            UUID organizationId, int page, int size,
-            String sort, String dir) {
+            UUID organizationId,
+            PageRequest pageReq) {
         Slice<Item> s = delegate.findByOrganizationId(
-                organizationId,
-                pageOf(page, size, sort, dir));
+                organizationId, toSpring(pageReq));
         return PageResultConverter.toPageResult(s);
     }
 
@@ -71,10 +70,10 @@ public class JpaItemRepositoryAdapter
     @Override
     public PageResult<Item> searchByOrganizationId(
             UUID organizationId, String query,
-            int page, int size, String sort, String dir) {
+            PageRequest pageReq) {
         Slice<Item> s = delegate.searchByOrganizationId(
                 organizationId, query,
-                pageOf(page, size, sort, dir));
+                toSpring(pageReq));
         return PageResultConverter.toPageResult(s);
     }
 
@@ -109,12 +108,11 @@ public class JpaItemRepositoryAdapter
     public PageResult<Item>
             findByCategoryAndOrganizationId(
                     UUID organizationId, String category,
-                    int page, int size,
-                    String sort, String dir) {
+                    PageRequest pageReq) {
         Slice<Item> s = delegate
                 .findByCategoryAndOrganizationId(
                         organizationId, category,
-                        pageOf(page, size, sort, dir));
+                        toSpring(pageReq));
         return PageResultConverter.toPageResult(s);
     }
 
@@ -123,12 +121,12 @@ public class JpaItemRepositoryAdapter
     public PageResult<Item>
             searchByCategoryAndOrganizationId(
                     UUID organizationId, String query,
-                    String category, int page, int size,
-                    String sort, String dir) {
+                    String category,
+                    PageRequest pageReq) {
         Slice<Item> s = delegate
                 .searchByCategoryAndOrganizationId(
                         organizationId, query, category,
-                        pageOf(page, size, sort, dir));
+                        toSpring(pageReq));
         return PageResultConverter.toPageResult(s);
     }
 
@@ -154,16 +152,19 @@ public class JpaItemRepositoryAdapter
             Set.of("name", "location", "category",
                     "manufacturer");
 
-    private PageRequest pageOf(int page, int size,
-            String sort, String dir) {
-        String field = SORTABLE_FIELDS.contains(sort)
-                ? sort : "name";
+    private org.springframework.data.domain.PageRequest
+            toSpring(PageRequest req) {
+        String field =
+                SORTABLE_FIELDS.contains(req.sort())
+                        ? req.sort() : "name";
         Sort.Direction direction =
-                "desc".equalsIgnoreCase(dir)
+                "desc".equalsIgnoreCase(req.dir())
                         ? Sort.Direction.DESC
                         : Sort.Direction.ASC;
-        return PageRequest.of(page, size,
-                Sort.by(direction, field));
+        return org.springframework.data.domain
+                .PageRequest.of(
+                        req.page(), req.size(),
+                        Sort.by(direction, field));
     }
 
 }

--- a/src/test/java/solutions/mystuff/domain/service/ItemQueryServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ItemQueryServiceTest.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
+import solutions.mystuff.domain.model.PageRequest;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.UuidV7;
 import solutions.mystuff.domain.port.out.ItemRepository;
@@ -35,6 +36,8 @@ class ItemQueryServiceTest {
                     schedRepo);
 
     private final UUID orgId = UuidV7.generate();
+    private final PageRequest pageReq =
+            new PageRequest(0, 10, "name", "asc");
 
     @Test
     @DisplayName("should delegate findByOrganization")
@@ -42,11 +45,11 @@ class ItemQueryServiceTest {
         PageResult<Item> expected = new PageResult<>(
                 List.of(), 0, 10, false);
         when(itemRepo.findByOrganizationId(
-                orgId, 0, 10, "name", "asc"))
+                orgId, pageReq))
                 .thenReturn(expected);
         assertEquals(expected,
                 service.findByOrganization(
-                        orgId, 0, 10, "name", "asc"));
+                        orgId, pageReq));
     }
 
     @Test
@@ -55,12 +58,11 @@ class ItemQueryServiceTest {
         PageResult<Item> expected = new PageResult<>(
                 List.of(), 0, 10, false);
         when(itemRepo.searchByOrganizationId(
-                orgId, "test", 0, 10, "name", "asc"))
+                orgId, "test", pageReq))
                 .thenReturn(expected);
         assertEquals(expected,
                 service.searchByOrganization(
-                        orgId, "test", 0, 10,
-                        "name", "asc"));
+                        orgId, "test", pageReq));
     }
 
     @Test
@@ -122,12 +124,11 @@ class ItemQueryServiceTest {
         PageResult<Item> expected = new PageResult<>(
                 List.of(), 0, 10, false);
         when(itemRepo.findByCategoryAndOrganizationId(
-                orgId, "HVAC", 0, 10, "name", "asc"))
+                orgId, "HVAC", pageReq))
                 .thenReturn(expected);
         assertEquals(expected,
                 service.findByCategoryAndOrganization(
-                        orgId, "HVAC", 0, 10,
-                        "name", "asc"));
+                        orgId, "HVAC", pageReq));
     }
 
     @Test
@@ -137,12 +138,10 @@ class ItemQueryServiceTest {
         PageResult<Item> expected = new PageResult<>(
                 List.of(), 0, 10, false);
         when(itemRepo.searchByCategoryAndOrganizationId(
-                orgId, "test", "HVAC", 0, 10,
-                "name", "asc"))
+                orgId, "test", "HVAC", pageReq))
                 .thenReturn(expected);
         assertEquals(expected,
                 service.searchByCategoryAndOrganization(
-                        orgId, "test", "HVAC", 0, 10,
-                        "name", "asc"));
+                        orgId, "test", "HVAC", pageReq));
     }
 }


### PR DESCRIPTION
## Summary
- New `PageRequest` record in domain model with `page`, `size`, `sort`, `dir` fields
- Convenience constructor defaulting sort to `name`/`asc`
- Replace trailing 4 params (`page, size, sort, dir`) with single `PageRequest` on:
  - `ItemQuery` (4 methods), `ItemRepository` (4 methods), `ItemQueryService`, `JpaItemRepositoryAdapter`
- Updated `ItemController` and `ItemApiController` to construct `PageRequest`
- Updated `ItemQueryServiceTest` mocks

Closes #60

## Test plan
- [ ] CI passes
- [ ] Items list pagination, sorting, search, and category filtering all work
- [ ] API pagination works

🤖 Generated with [Claude Code](https://claude.com/claude-code)