### PR TITLE
Add CSS linting with Stylelint in CI (ADR-0029)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+    - name: Lint CSS
+      run: npx stylelint "src/main/resources/static/css/**/*.css"
     - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,9 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Lint CSS
-      run: npx stylelint "src/main/resources/static/css/**/*.css"
+      run: |
+        npm install --no-save stylelint stylelint-config-standard
+        npx stylelint "src/main/resources/static/css/**/*.css"
     - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "no-empty-source": true,
+    "block-no-empty": true,
+    "no-duplicate-selectors": true,
+    "selector-class-pattern": null,
+    "custom-property-pattern": null,
+    "keyframes-name-pattern": null,
+    "no-descending-specificity": null,
+    "declaration-block-no-duplicate-properties": true
+  }
+}

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,10 +4,15 @@
     "no-empty-source": true,
     "block-no-empty": true,
     "no-duplicate-selectors": true,
+    "declaration-block-no-duplicate-properties": true,
     "selector-class-pattern": null,
     "custom-property-pattern": null,
     "keyframes-name-pattern": null,
     "no-descending-specificity": null,
-    "declaration-block-no-duplicate-properties": true
+    "color-function-alias-notation": null,
+    "color-function-notation": null,
+    "alpha-value-notation": null,
+    "media-feature-range-notation": null,
+    "shorthand-property-no-redundant-values": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -13,6 +13,7 @@
     "color-function-notation": null,
     "alpha-value-notation": null,
     "media-feature-range-notation": null,
-    "shorthand-property-no-redundant-values": null
+    "shorthand-property-no-redundant-values": null,
+    "declaration-block-single-line-max-declarations": null
   }
 }

--- a/doc/adr/0029-css-linting-with-stylelint.md
+++ b/doc/adr/0029-css-linting-with-stylelint.md
@@ -1,0 +1,33 @@
+# 29. CSS linting with Stylelint
+
+Date: 2026-03-20
+
+## Status
+
+Accepted
+
+## Context
+
+Multiple PRs have introduced CSS syntax errors (unclosed braces) that broke styling across the application. These errors are invisible at compile time because CSS files are static resources — the Java build has no awareness of CSS validity. Broken CSS reaches production silently.
+
+We need automated CSS validation that:
+
+1. Catches syntax errors (missing braces, invalid properties) before merge
+2. Enforces consistent formatting
+3. Does not add Node.js to the Java build or Docker image
+4. Aligns with the project convention of minimal dependencies
+
+## Decision
+
+1. **Use [Stylelint](https://stylelint.io/)** — the standard CSS linter. It is free, open-source, and widely adopted.
+2. **Run via `npx` in CI only** — GitHub Actions runners have Node pre-installed. No `package.json`, no `node_modules`, no changes to `pom.xml` or `Dockerfile`. Developers can optionally run `npx stylelint` locally.
+3. **Configuration** — a `.stylelintrc.json` at project root extending `stylelint-config-standard` with minimal overrides for our conventions (CSS custom properties, Thymeleaf-compatible selectors).
+4. **CI enforcement** — add a `lint-css` step to `.github/workflows/maven.yml` that runs before the Maven build. Failures block the PR from merging.
+5. **No Maven plugin** — `frontend-maven-plugin` would add Node to the build, increasing complexity and build time. The CI-only approach keeps the Java build purely Java.
+
+## Consequences
+
+- CSS syntax errors will be caught before merge, preventing the recurring unclosed-brace bugs.
+- CI adds ~5 seconds for the stylelint step.
+- Developers without Node installed can still build and test locally; CSS linting is enforced in CI.
+- If Stylelint rules need updating, only `.stylelintrc.json` changes — no build system impact.


### PR DESCRIPTION
## Summary
- **ADR-0029**: Documents decision to use Stylelint for CSS validation, run via `npx` in CI only
- **`.stylelintrc.json`**: Extends `stylelint-config-standard` with rules for syntax errors, empty blocks, duplicate selectors/properties
- **`maven.yml`**: Adds "Lint CSS" step before Maven build — bad CSS blocks the PR

## Why
Multiple PRs introduced unclosed CSS braces that broke styling in production. The Java build has no awareness of CSS validity, so these errors passed CI silently.

## Approach
- **CI-only via `npx`** — GitHub Actions runners have Node pre-installed, zero changes to pom.xml or Dockerfile
- **No Node in the project** — no `package.json`, no `node_modules`, no `frontend-maven-plugin`
- **~5 seconds added to CI** — runs before the Maven build

## Test plan
- [ ] CI lint step runs and passes (or reports fixable issues)
- [ ] Intentionally break CSS syntax in a branch — verify CI fails
- [ ] Maven build still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)