### PR TITLE
Add bulk operations for items

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/ItemController.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemController.java
@@ -3,6 +3,7 @@ package solutions.mystuff.application.web;
 import java.math.BigDecimal;
 import java.security.Principal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.AppUser;
@@ -46,7 +47,7 @@ import org.springframework.web.servlet.mvc
  * <div class="mermaid">
  * sequenceDiagram
  *     Browser->>ItemController: GET/POST/PUT/DELETE /items
- *     ItemController->>ItemManagement: create/update/delete
+ *     ItemController->>ItemManagement: create/update/delete/bulk
  *     ItemController->>ItemQuery: find/search/filter
  *     ItemController-->>Browser: HTML (Thymeleaf)
  * </div>
@@ -300,6 +301,54 @@ public class ItemController {
                 itemId);
         redirectAttrs.addFlashAttribute(
                 "success", "Item deleted");
+        return "redirect:/items";
+    }
+
+    @Operation(summary = "Bulk delete items",
+            description = "Deletes multiple items by ID.",
+            responses = {
+                    @ApiResponse(responseCode = "302",
+                            description = "Redirect to"
+                                    + " /items")})
+    @PostMapping("/items/bulk-delete")
+    public String bulkDelete(
+            @RequestParam("itemIds")
+                    List<UUID> itemIds,
+            Principal principal,
+            RedirectAttributes redirectAttrs) {
+        AppUser user = helper.resolveUser(principal);
+        helper.setOrgMdc(user);
+        itemService.bulkDelete(
+                user.getOrganization().getId(),
+                itemIds);
+        redirectAttrs.addFlashAttribute("success",
+                itemIds.size() + " item(s) deleted");
+        return "redirect:/items";
+    }
+
+    @Operation(summary = "Bulk update category",
+            description = "Updates category for"
+                    + " multiple items.",
+            responses = {
+                    @ApiResponse(responseCode = "302",
+                            description = "Redirect to"
+                                    + " /items")})
+    @PostMapping("/items/bulk-category")
+    public String bulkUpdateCategory(
+            @RequestParam("itemIds")
+                    List<UUID> itemIds,
+            @RequestParam("category")
+                    String category,
+            Principal principal,
+            RedirectAttributes redirectAttrs) {
+        AppUser user = helper.resolveUser(principal);
+        helper.setOrgMdc(user);
+        itemService.bulkUpdateCategory(
+                user.getOrganization().getId(),
+                itemIds, category);
+        redirectAttrs.addFlashAttribute("success",
+                itemIds.size()
+                        + " item(s) updated");
         return "redirect:/items";
     }
 

--- a/src/main/java/solutions/mystuff/domain/model/Validation.java
+++ b/src/main/java/solutions/mystuff/domain/model/Validation.java
@@ -1,6 +1,7 @@
 package solutions.mystuff.domain.model;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
@@ -17,6 +18,7 @@ import java.util.regex.Pattern;
  *         +requirePositive(int, String) void
  *         +requireYearInRange(Integer, String) void
  *         +requireNonNegative(BigDecimal, String) void
+ *         +requireNotEmpty(List, String) void
  *     }
  * </div>
  */
@@ -94,6 +96,15 @@ public final class Validation {
                             + " must be between "
                             + MIN_YEAR + " and "
                             + MAX_YEAR);
+        }
+    }
+
+    /** Validates that the list is not null or empty. */
+    public static void requireNotEmpty(
+            List<?> list, String fieldName) {
+        if (list == null || list.isEmpty()) {
+            throw new IllegalArgumentException(
+                    fieldName + " must not be empty");
         }
     }
 

--- a/src/main/java/solutions/mystuff/domain/port/in/ItemManagement.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/ItemManagement.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.domain.port.in;
 
+import java.util.List;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
@@ -14,6 +15,8 @@ import solutions.mystuff.domain.model.ItemSpec;
  *         +createItem(UUID, ItemSpec) Item
  *         +updateItem(UUID, UUID, ItemSpec) Item
  *         +deleteItem(UUID, UUID) void
+ *         +bulkDelete(UUID, List~UUID~) void
+ *         +bulkUpdateCategory(UUID, List~UUID~, String) void
  *     }
  *     ItemManagementService ..|> ItemManagement
  * </div>
@@ -31,5 +34,12 @@ public interface ItemManagement {
 
     /** Delete an item by ID within an organization. */
     void deleteItem(UUID orgId, UUID itemId);
+
+    /** Bulk-delete items by IDs within an organization. */
+    void bulkDelete(UUID orgId, List<UUID> itemIds);
+
+    /** Bulk-update category for items within an organization. */
+    void bulkUpdateCategory(UUID orgId,
+            List<UUID> itemIds, String category);
 
 }

--- a/src/main/java/solutions/mystuff/domain/port/out/ItemRepository.java
+++ b/src/main/java/solutions/mystuff/domain/port/out/ItemRepository.java
@@ -25,6 +25,8 @@ import solutions.mystuff.domain.model.PageResult;
  *         +searchByCategoryAndOrganizationId(UUID, String, String, PageRequest) PageResult~Item~
  *         +save(Item) Item
  *         +deleteByIdAndOrganizationId(UUID, UUID) void
+ *         +deleteAllByIdsAndOrganizationId(List~UUID~, UUID) void
+ *         +updateCategoryByIdsAndOrganizationId(List~UUID~, UUID, String) void
  *     }
  *     JpaItemRepositoryAdapter ..|> ItemRepository
  * </div>
@@ -76,4 +78,13 @@ public interface ItemRepository {
     /** Delete an item by ID scoped to an organization. */
     void deleteByIdAndOrganizationId(
             UUID id, UUID organizationId);
+
+    /** Bulk-delete items by IDs scoped to an organization. */
+    void deleteAllByIdsAndOrganizationId(
+            List<UUID> ids, UUID organizationId);
+
+    /** Bulk-update category for items by IDs within an organization. */
+    void updateCategoryByIdsAndOrganizationId(
+            List<UUID> ids, UUID organizationId,
+            String category);
 }

--- a/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
+++ b/src/main/java/solutions/mystuff/domain/service/ItemManagementService.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.domain.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.Item;
@@ -85,6 +86,34 @@ public class ItemManagementService
         itemRepo.deleteByIdAndOrganizationId(
                 itemId, orgId);
         log.info("Deleted item {}", item.getName());
+    }
+
+    /** Validates the list and bulk-deletes items. */
+    @Override
+    @Transactional
+    public void bulkDelete(
+            UUID orgId, List<UUID> itemIds) {
+        Validation.requireNotEmpty(itemIds, "Item IDs");
+        itemRepo.deleteAllByIdsAndOrganizationId(
+                itemIds, orgId);
+        log.info("Bulk-deleted {} items", itemIds.size());
+    }
+
+    /** Validates inputs and bulk-updates category. */
+    @Override
+    @Transactional
+    public void bulkUpdateCategory(
+            UUID orgId, List<UUID> itemIds,
+            String category) {
+        Validation.requireNotEmpty(itemIds, "Item IDs");
+        String trimCat = Validation.requireNotBlank(
+                category, "Category");
+        Validation.requireMaxLength(
+                trimCat, "Category", CATEGORY_MAX);
+        itemRepo.updateCategoryByIdsAndOrganizationId(
+                itemIds, orgId, trimCat);
+        log.info("Bulk-updated category to '{}' for {}"
+                + " items", trimCat, itemIds.size());
     }
 
     private Item requireItem(UUID orgId, UUID itemId) {

--- a/src/main/java/solutions/mystuff/infrastructure/persistence/JpaItemRepositoryAdapter.java
+++ b/src/main/java/solutions/mystuff/infrastructure/persistence/JpaItemRepositoryAdapter.java
@@ -148,6 +148,27 @@ public class JpaItemRepositoryAdapter
                 id, organizationId);
     }
 
+    /**
+     * Bulk-deletes items via JPQL, bypassing Hibernate
+     * entity-level cascade. The database
+     * {@code ON DELETE CASCADE} removes children.
+     */
+    @Override
+    public void deleteAllByIdsAndOrganizationId(
+            List<UUID> ids, UUID organizationId) {
+        delegate.deleteAllByIdsAndOrganizationId(
+                ids, organizationId);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateCategoryByIdsAndOrganizationId(
+            List<UUID> ids, UUID organizationId,
+            String category) {
+        delegate.updateCategoryByIdsAndOrganizationId(
+                ids, organizationId, category);
+    }
+
     private static final Set<String> SORTABLE_FIELDS =
             Set.of("name", "location", "category",
                     "manufacturer");

--- a/src/main/java/solutions/mystuff/infrastructure/persistence/SpringDataItemRepository.java
+++ b/src/main/java/solutions/mystuff/infrastructure/persistence/SpringDataItemRepository.java
@@ -1,5 +1,6 @@
 package solutions.mystuff.infrastructure.persistence;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -105,5 +106,33 @@ interface SpringDataItemRepository
     void deleteByIdAndOrganizationId(
             @Param("id") UUID id,
             @Param("orgId") UUID organizationId);
+
+    /**
+     * Bulk-deletes items by IDs and organization using JPQL.
+     * Relies on the database {@code ON DELETE CASCADE} on
+     * child tables.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Item i "
+            + "WHERE i.id IN :ids "
+            + "AND i.organizationId = :orgId")
+    void deleteAllByIdsAndOrganizationId(
+            @Param("ids") Collection<UUID> ids,
+            @Param("orgId") UUID organizationId);
+
+    /**
+     * Bulk-updates category for items by IDs within an
+     * organization.
+     */
+    @Modifying
+    @Transactional
+    @Query("UPDATE Item i SET i.category = :cat "
+            + "WHERE i.id IN :ids "
+            + "AND i.organizationId = :orgId")
+    void updateCategoryByIdsAndOrganizationId(
+            @Param("ids") Collection<UUID> ids,
+            @Param("orgId") UUID organizationId,
+            @Param("cat") String category);
 
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -875,5 +875,26 @@ textarea:focus-visible,
 
 .confirm-delete:hover {
     background: #b71c1c;
+}
 
+/* --- Bulk toolbar --- */
+.bulk-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    background: var(--bg-form);
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    margin-bottom: 0.75rem;
+    border: 1px solid var(--color-border);
+}
+
+.bulk-toolbar #bulk-count {
+    font-weight: bold;
+    white-space: nowrap;
+}
+
+.bulk-check {
+    width: 2rem;
+    text-align: center;
 }

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -119,10 +119,13 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
 
+        if (e.target.closest('[data-stop-propagation]')) {
+            return;
+        }
+
         var link =
             e.target.closest('[data-navigate]');
-        if (link && !e.target.closest('td.actions')
-                && !e.target.closest('td.bulk-check')) {
+        if (link && !e.target.closest('td.actions')) {
             window.location.href =
                 link.getAttribute('data-navigate');
             return;

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -121,7 +121,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
         var link =
             e.target.closest('[data-navigate]');
-        if (link && !e.target.closest('td.actions')) {
+        if (link && !e.target.closest('td.actions')
+                && !e.target.closest('td.bulk-check')) {
             window.location.href =
                 link.getAttribute('data-navigate');
             return;
@@ -245,6 +246,85 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
     }
+
+    /* --- Bulk selection --- */
+    var selectAll =
+        document.getElementById('select-all');
+    if (selectAll) {
+        selectAll.addEventListener('change', function () {
+            var boxes = document.querySelectorAll(
+                '.item-checkbox');
+            boxes.forEach(function (cb) {
+                cb.checked = selectAll.checked;
+            });
+            updateBulkToolbar();
+        });
+        document.body.addEventListener('change',
+            function (e) {
+                if (e.target.classList
+                        .contains('item-checkbox')) {
+                    updateBulkToolbar();
+                }
+            });
+    }
+
+    function getSelectedIds() {
+        var ids = [];
+        document.querySelectorAll(
+            '.item-checkbox:checked'
+        ).forEach(function (cb) {
+            ids.push(cb.value);
+        });
+        return ids;
+    }
+
+    function updateBulkToolbar() {
+        var ids = getSelectedIds();
+        var toolbar =
+            document.getElementById('bulk-toolbar');
+        if (!toolbar) {
+            return;
+        }
+        if (ids.length > 0) {
+            toolbar.style.display = '';
+            document.getElementById('bulk-count')
+                .textContent = ids.length + ' selected';
+        } else {
+            toolbar.style.display = 'none';
+        }
+    }
+
+    document.body.addEventListener('submit', function (e) {
+        var bulkDelete =
+            e.target.id === 'bulk-delete-form';
+        var bulkCategory =
+            e.target.id === 'bulk-category-form';
+        if (bulkDelete || bulkCategory) {
+            var ids = getSelectedIds();
+            if (ids.length === 0) {
+                e.preventDefault();
+                return;
+            }
+            var idField = bulkDelete
+                ? 'bulk-delete-ids'
+                : 'bulk-category-ids';
+            document.getElementById(idField)
+                .value = ids.join(',');
+            if (bulkDelete) {
+                var btn = e.target.querySelector(
+                    '[data-confirm-submit]');
+                if (btn) {
+                    btn.setAttribute(
+                        'data-confirm-submit',
+                        'Delete ' + ids.length
+                            + ' selected item(s)'
+                            + ' and all their'
+                            + ' schedules and'
+                            + ' records?');
+                }
+            }
+        }
+    });
 
     document.addEventListener('keydown', function (e) {
         if (e.key === 'Escape') {

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -189,7 +189,7 @@
                 <tr class="item-row"
                     th:classappend="${selectedItemId != null and selectedItemId.equals(item.id)} ? ' selected'"
                     th:data-navigate="@{/items/{id}(id=${item.id})}">
-                    <td class="bulk-check" onclick="event.stopPropagation()">
+                    <td class="bulk-check" data-stop-propagation>
                         <input type="checkbox" class="item-checkbox"
                                th:value="${item.id}"/>
                     </td>

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -99,6 +99,32 @@
                     </button>
                 </form>
             </div>
+            <div id="bulk-toolbar" style="display:none" class="bulk-toolbar">
+                <span id="bulk-count">0 selected</span>
+                <form id="bulk-delete-form" method="post" th:action="@{/items/bulk-delete}"
+                      style="display:inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <input type="hidden" name="itemIds" id="bulk-delete-ids"/>
+                    <button type="submit" class="btn-icon btn-delete"
+                            data-confirm-submit="Delete selected items and all their schedules and records?">
+                        <svg th:replace="~{fragments/icons :: icon-trash}"></svg>
+                        Delete
+                    </button>
+                </form>
+                <form id="bulk-category-form" method="post" th:action="@{/items/bulk-category}"
+                      style="display:inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <input type="hidden" name="itemIds" id="bulk-category-ids"/>
+                    <label>Category
+                        <input type="text" name="category" placeholder="New category"
+                               list="category-suggestions" required/>
+                    </label>
+                    <button type="submit" class="btn-icon btn-edit">
+                        <svg th:replace="~{fragments/icons :: icon-save}"></svg>
+                        Apply
+                    </button>
+                </form>
+            </div>
             <div th:if="${#lists.isEmpty(items)}" class="empty-state">
                 <p>No items yet. Click <strong>+ Add Item</strong> above to get started.</p>
                 <div class="empty-state-cta">
@@ -115,6 +141,7 @@
             <table th:unless="${#lists.isEmpty(items)}">
                 <thead>
                 <tr>
+                    <th><input type="checkbox" id="select-all" title="Select all"/></th>
                     <th class="sortable">
                         <a th:href="@{/items(q=${q},category=${selectedCategory},page=${itemPage.page()},size=${itemPage.size()},sort='name',dir=${itemPage.sort() == 'name' and itemPage.dir() == 'asc' ? 'desc' : 'asc'})}"
                            th:classappend="${itemPage.sort() == 'name' ? 'sort-active' : ''}">
@@ -162,6 +189,10 @@
                 <tr class="item-row"
                     th:classappend="${selectedItemId != null and selectedItemId.equals(item.id)} ? ' selected'"
                     th:data-navigate="@{/items/{id}(id=${item.id})}">
+                    <td class="bulk-check" onclick="event.stopPropagation()">
+                        <input type="checkbox" class="item-checkbox"
+                               th:value="${item.id}"/>
+                    </td>
                     <td th:text="${item.name}"></td>
                     <td th:text="${item.location}"></td>
                     <td th:text="${item.category}"></td>
@@ -196,7 +227,7 @@
                     </td>
                 </tr>
                 <tr th:id="'edit-item-' + ${item.id}" class="form-row" style="display:none">
-                    <td colspan="8">
+                    <td colspan="9">
                         <form th:action="@{/items/{id}(id=${item.id})}" method="post" class="inline-form">
                             <input type="hidden" name="_method" value="PUT"/>
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
@@ -234,7 +265,7 @@
                     </td>
                 </tr>
                 <tr th:id="'item-oneoff-' + ${item.id}" class="form-row" style="display:none">
-                    <td colspan="8">
+                    <td colspan="9">
                         <form method="post" th:action="@{/items/{id}/service-records(id=${item.id})}" class="inline-form">
                             <input type="hidden" name="oneOff" value="true"/>
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
@@ -259,7 +290,7 @@
                     </td>
                 </tr>
                 <tr th:id="'item-sched-' + ${item.id}" class="form-row" style="display:none">
-                    <td colspan="8">
+                    <td colspan="9">
                         <form method="post" th:action="@{/items/{id}/schedules(id=${item.id})}" class="inline-form">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                             <label>Type <input type="text"
@@ -289,7 +320,7 @@
                 </tr>
                 <tr th:if="${selectedItemId != null and selectedItemId.equals(item.id)}"
                     class="detail-row">
-                    <td colspan="8">
+                    <td colspan="9">
                         <div class="item-detail">
                             <div class="detail-section"
                                  th:if="${itemRecords != null and !#lists.isEmpty(itemRecords)}">
@@ -339,7 +370,7 @@
                                     </tr>
                                     <tr th:id="'edit-record-' + ${r.id}"
                                         class="form-row" style="display:none">
-                                        <td colspan="8">
+                                        <td colspan="9">
                                             <form method="post"
                                                   th:action="@{/items/{itemId}/records/{recordId}(itemId=${item.id},recordId=${r.id})}"
                                                   class="inline-form">

--- a/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/ItemControllerIntegrationTest.java
@@ -1373,6 +1373,85 @@ class ItemControllerIntegrationTest {
                 "should render sort arrow indicator");
     }
 
+    @Test
+    @DisplayName("should bulk delete items")
+    void shouldBulkDeleteItems() throws Exception {
+        mockMvc.perform(post("/items")
+                .param("name", "Bulk Del A")
+                .with(user("dev").roles("USER"))
+                .with(csrf()));
+        mockMvc.perform(post("/items")
+                .param("name", "Bulk Del B")
+                .with(user("dev").roles("USER"))
+                .with(csrf()));
+        String idA = getItemIdByName("Bulk Del A");
+        String idB = getItemIdByName("Bulk Del B");
+        mockMvc.perform(post("/items/bulk-delete")
+                        .param("itemIds", idA + "," + idB)
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/items"));
+    }
+
+    @Test
+    @DisplayName("should bulk update category")
+    void shouldBulkUpdateCategory() throws Exception {
+        mockMvc.perform(post("/items")
+                .param("name", "Bulk Cat A")
+                .with(user("dev").roles("USER"))
+                .with(csrf()));
+        String idA = getItemIdByName("Bulk Cat A");
+        mockMvc.perform(post("/items/bulk-category")
+                        .param("itemIds", idA)
+                        .param("category", "Plumbing")
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/items"));
+    }
+
+    @Test
+    @DisplayName("should render bulk toolbar markup")
+    void shouldRenderBulkToolbar() throws Exception {
+        MvcResult result = mockMvc.perform(
+                get("/items")
+                        .with(user("dev").roles("USER")))
+                .andExpect(status().isOk())
+                .andReturn();
+        String html = result.getResponse()
+                .getContentAsString();
+        assertTrue(html.contains("bulk-toolbar"),
+                "should include bulk toolbar");
+        assertTrue(html.contains("select-all"),
+                "should include select-all checkbox");
+        assertTrue(html.contains("item-checkbox"),
+                "should include item checkboxes");
+    }
+
+    @Test
+    @DisplayName("should reject bulk delete without IDs")
+    void shouldRejectBulkDeleteWithoutIds()
+            throws Exception {
+        mockMvc.perform(post("/items/bulk-delete")
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("should reject bulk category without"
+            + " category")
+    void shouldRejectBulkCategoryWithoutCategory()
+            throws Exception {
+        String idA = getFirstItemId();
+        mockMvc.perform(post("/items/bulk-category")
+                        .param("itemIds", idA)
+                        .with(user("dev").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
     private Object getModel(String attr)
             throws Exception {
         MvcResult result = mockMvc.perform(get("/items")

--- a/src/test/java/solutions/mystuff/domain/service/ItemManagementServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/ItemManagementServiceTest.java
@@ -1,6 +1,7 @@
 package solutions.mystuff.domain.service;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -206,6 +207,64 @@ class ItemManagementServiceTest {
                 null, null, null, null);
         Item item = service.createItem(orgId, spec);
         assertNull(item.getModelYear());
+    }
+
+    @Test
+    @DisplayName("should bulk delete items")
+    void shouldBulkDeleteItems() {
+        List<UUID> ids = List.of(
+                UuidV7.generate(), UuidV7.generate());
+        service.bulkDelete(orgId, ids);
+        verify(itemRepo)
+                .deleteAllByIdsAndOrganizationId(
+                        ids, orgId);
+    }
+
+    @Test
+    @DisplayName("should reject empty list on"
+            + " bulk delete")
+    void shouldRejectEmptyBulkDelete() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.bulkDelete(
+                        orgId, List.of()));
+    }
+
+    @Test
+    @DisplayName("should reject null list on"
+            + " bulk delete")
+    void shouldRejectNullBulkDelete() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.bulkDelete(orgId, null));
+    }
+
+    @Test
+    @DisplayName("should bulk update category")
+    void shouldBulkUpdateCategory() {
+        List<UUID> ids = List.of(UuidV7.generate());
+        service.bulkUpdateCategory(
+                orgId, ids, "Plumbing");
+        verify(itemRepo)
+                .updateCategoryByIdsAndOrganizationId(
+                        ids, orgId, "Plumbing");
+    }
+
+    @Test
+    @DisplayName("should reject blank category on"
+            + " bulk update")
+    void shouldRejectBlankBulkCategory() {
+        List<UUID> ids = List.of(UuidV7.generate());
+        assertThrows(IllegalArgumentException.class,
+                () -> service.bulkUpdateCategory(
+                        orgId, ids, "  "));
+    }
+
+    @Test
+    @DisplayName("should reject empty list on"
+            + " bulk category update")
+    void shouldRejectEmptyBulkCategory() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.bulkUpdateCategory(
+                        orgId, List.of(), "HVAC"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add multi-select checkboxes to items table with select-all header
- Bulk action toolbar (hidden until items selected) with Delete and Change Category
- `POST /items/bulk-delete` and `POST /items/bulk-category` endpoints
- Bulk JPQL operations scoped by organization ID for efficiency
- `Validation.requireNotEmpty()` utility for list validation
- Confirmation dialog shows count of selected items
- 11 new tests (5 integration, 6 unit)

Closes #80

## Test plan
- [ ] CI passes
- [ ] Select items with checkboxes — toolbar appears showing count
- [ ] Select all checkbox selects/deselects all
- [ ] Bulk delete removes selected items
- [ ] Bulk category change updates selected items
- [ ] Empty selection is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)