### PR TITLE
Add audit trail and activity feed

### DIFF
--- a/src/main/java/solutions/mystuff/application/web/ActivityController.java
+++ b/src/main/java/solutions/mystuff/application/web/ActivityController.java
@@ -1,0 +1,76 @@
+package solutions.mystuff.application.web;
+
+import java.security.Principal;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.AppUser;
+import solutions.mystuff.domain.port.in.AuditLog;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Displays the full audit log activity feed.
+ *
+ * <div class="mermaid">
+ * sequenceDiagram
+ *     Browser-&gt;&gt;ActivityController: GET /activity
+ *     ActivityController-&gt;&gt;AuditLog: findRecentByOrganization(...)
+ *     AuditLog--&gt;&gt;ActivityController: List~AuditEntry~
+ *     ActivityController--&gt;&gt;Browser: activity view
+ * </div>
+ *
+ * @see AuditLog
+ * @see ControllerHelper
+ */
+@Controller
+@Tag(name = "Activity",
+        description = "Audit trail activity feed")
+public class ActivityController {
+
+    private static final int ACTIVITY_LIMIT = 50;
+
+    private final ControllerHelper helper;
+    private final AuditLog auditLog;
+
+    /** Creates the controller with its dependencies. */
+    public ActivityController(
+            ControllerHelper helper,
+            AuditLog auditLog) {
+        this.helper = helper;
+        this.auditLog = auditLog;
+    }
+
+    /**
+     * Renders the full activity feed page.
+     *
+     * @param principal the authenticated user
+     * @param model the view model
+     * @return the activity view name
+     */
+    @Operation(summary = "Activity feed",
+            description = "Shows the full audit trail"
+                    + " for the organization.",
+            responses = @ApiResponse(
+                    responseCode = "200",
+                    description = "HTML activity page"))
+    @GetMapping("/activity")
+    public String activity(
+            Principal principal, Model model) {
+        AppUser user = helper.resolveUser(principal);
+        if (!user.hasOrganization()) {
+            return helper.handleNoOrg(
+                    user, model, "activity");
+        }
+        helper.setOrgMdc(user);
+        helper.addUserAttrs(user, model);
+        UUID orgId = user.getOrganization().getId();
+        model.addAttribute("auditEntries",
+                auditLog.findRecentByOrganization(
+                        orgId, ACTIVITY_LIMIT));
+        return "activity";
+    }
+}

--- a/src/main/java/solutions/mystuff/application/web/DashboardController.java
+++ b/src/main/java/solutions/mystuff/application/web/DashboardController.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.AppUser;
+import solutions.mystuff.domain.port.in.AuditLog;
 import solutions.mystuff.domain.port.in.DashboardQuery;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -45,13 +46,16 @@ public class DashboardController {
 
     private final ControllerHelper helper;
     private final DashboardQuery dashboardQuery;
+    private final AuditLog auditLog;
 
     /** Creates the controller with its dependencies. */
     public DashboardController(
             ControllerHelper helper,
-            DashboardQuery dashboardQuery) {
+            DashboardQuery dashboardQuery,
+            AuditLog auditLog) {
         this.helper = helper;
         this.dashboardQuery = dashboardQuery;
+        this.auditLog = auditLog;
     }
 
     /**
@@ -100,6 +104,9 @@ public class DashboardController {
                 dashboardQuery.countItems(orgId));
         model.addAttribute("recentRecords",
                 dashboardQuery.findRecentRecords(
+                        orgId, RECENT_LIMIT));
+        model.addAttribute("auditEntries",
+                auditLog.findRecentByOrganization(
                         orgId, RECENT_LIMIT));
     }
 }

--- a/src/main/java/solutions/mystuff/application/web/ItemController.java
+++ b/src/main/java/solutions/mystuff/application/web/ItemController.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.AppUser;
+import solutions.mystuff.domain.model.AuditAction;
 import solutions.mystuff.domain.model.FrequencyUnit;
 import solutions.mystuff.domain.model.Item;
 import solutions.mystuff.domain.model.ItemSpec;
@@ -14,7 +15,9 @@ import solutions.mystuff.domain.model.PageRequest;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.Validation;
 import solutions.mystuff.domain.model.ServiceCompletion;
+import solutions.mystuff.domain.model.ServiceSchedule;
 import solutions.mystuff.domain.model.Vendor;
+import solutions.mystuff.domain.port.in.AuditLog;
 import solutions.mystuff.domain.port.in.ItemManagement;
 import solutions.mystuff.domain.port.in.ItemQuery;
 import solutions.mystuff.domain.port.in.RecordCreation;
@@ -69,6 +72,7 @@ public class ItemController {
     private final ScheduleLifecycle scheduleService;
     private final RecordCreation recordService;
     private final RecordManagement recordMgmt;
+    private final AuditLog auditLog;
 
     public ItemController(
             ControllerHelper helper,
@@ -77,7 +81,8 @@ public class ItemController {
             VendorQuery vendorQuery,
             ScheduleLifecycle scheduleService,
             RecordCreation recordService,
-            RecordManagement recordMgmt) {
+            RecordManagement recordMgmt,
+            AuditLog auditLog) {
         this.helper = helper;
         this.itemService = itemService;
         this.itemQuery = itemQuery;
@@ -85,6 +90,7 @@ public class ItemController {
         this.scheduleService = scheduleService;
         this.recordService = recordService;
         this.recordMgmt = recordMgmt;
+        this.auditLog = auditLog;
     }
 
     @Operation(summary = "List items",
@@ -220,7 +226,11 @@ public class ItemController {
                 manufacturer, modelName, serialNumber,
                 modelNumber, modelYear, category,
                 pd, notes);
-        itemService.createItem(orgId, spec);
+        Item created = itemService.createItem(orgId, spec);
+        auditLog.log(orgId, user.getUsername(),
+                "Item", created.getId(),
+                created.getName(),
+                AuditAction.CREATE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Item created");
         return "redirect:/items";
@@ -270,7 +280,12 @@ public class ItemController {
                 manufacturer, modelName, serialNumber,
                 modelNumber, modelYear, category,
                 pd, notes);
-        itemService.updateItem(orgId, itemId, spec);
+        Item updated = itemService.updateItem(
+                orgId, itemId, spec);
+        auditLog.log(orgId, user.getUsername(),
+                "Item", updated.getId(),
+                updated.getName(),
+                AuditAction.UPDATE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Item updated");
         return "redirect:/items";
@@ -295,9 +310,14 @@ public class ItemController {
             RedirectAttributes redirectAttrs) {
         AppUser user = helper.resolveUser(principal);
         helper.setOrgMdc(user);
-        itemService.deleteItem(
-                user.getOrganization().getId(),
-                itemId);
+        UUID orgId = user.getOrganization().getId();
+        String itemName = itemQuery
+                .findByIdAndOrganization(itemId, orgId)
+                .map(Item::getName).orElse("Unknown");
+        itemService.deleteItem(orgId, itemId);
+        auditLog.log(orgId, user.getUsername(),
+                "Item", itemId, itemName,
+                AuditAction.DELETE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Item deleted");
         return "redirect:/items";
@@ -355,6 +375,10 @@ public class ItemController {
             scheduleService.completeNextForItem(
                     orgId, itemId, completion);
         }
+        auditLog.log(orgId, user.getUsername(),
+                "Record", itemId, item.getName(),
+                AuditAction.CREATE,
+                "Service record logged");
         redirectAttrs.addFlashAttribute(
                 "success", "Service record logged");
         return "redirect:/items";
@@ -393,6 +417,9 @@ public class ItemController {
                 serviceDate, "Service date");
         recordMgmt.updateRecord(orgId, recordId,
                 summary, date, techName, cost);
+        auditLog.log(orgId, user.getUsername(),
+                "Record", recordId, summary,
+                AuditAction.UPDATE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Record updated");
         return "redirect:/items/" + itemId;
@@ -419,6 +446,9 @@ public class ItemController {
         helper.setOrgMdc(user);
         UUID orgId = user.getOrganization().getId();
         recordMgmt.deleteRecord(orgId, recordId);
+        auditLog.log(orgId, user.getUsername(),
+                "Record", recordId, "Service record",
+                AuditAction.DELETE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Record deleted");
         return "redirect:/items/" + itemId;
@@ -458,9 +488,13 @@ public class ItemController {
                 newVendorPhone);
         LocalDate due = InputValidator.parseDate(
                 nextDueDate, "Next due date");
-        scheduleService.createSchedule(orgId,
-                itemId, serviceType, vendor, due,
-                frequencyInterval, frequencyUnit);
+        ServiceSchedule sched =
+                scheduleService.createSchedule(orgId,
+                        itemId, serviceType, vendor, due,
+                        frequencyInterval, frequencyUnit);
+        auditLog.log(orgId, user.getUsername(),
+                "Schedule", sched.getId(),
+                serviceType, AuditAction.CREATE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Schedule created");
         if ("schedules".equals(redirectTo)) {
@@ -481,6 +515,8 @@ public class ItemController {
         model.addAttribute("itemSchedules",
                 itemQuery.findSchedulesByItem(
                         itemId, orgId));
+        model.addAttribute("itemAuditEntries",
+                auditLog.findByEntityId(itemId));
     }
 
     private void loadItems(

--- a/src/main/java/solutions/mystuff/application/web/ScheduleController.java
+++ b/src/main/java/solutions/mystuff/application/web/ScheduleController.java
@@ -6,11 +6,13 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.AppUser;
+import solutions.mystuff.domain.model.AuditAction;
 import solutions.mystuff.domain.model.FrequencyUnit;
 import solutions.mystuff.domain.model.PageResult;
 import solutions.mystuff.domain.model.ServiceCompletion;
 import solutions.mystuff.domain.model.ServiceSchedule;
 import solutions.mystuff.domain.model.Vendor;
+import solutions.mystuff.domain.port.in.AuditLog;
 import solutions.mystuff.domain.port.in.ScheduleLifecycle;
 import solutions.mystuff.domain.port.in.ScheduleQuery;
 import solutions.mystuff.domain.port.in.VendorQuery;
@@ -51,16 +53,19 @@ public class ScheduleController {
     private final ScheduleQuery scheduleQuery;
     private final VendorQuery vendorQuery;
     private final ScheduleLifecycle scheduleService;
+    private final AuditLog auditLog;
 
     public ScheduleController(
             ControllerHelper helper,
             ScheduleQuery scheduleQuery,
             VendorQuery vendorQuery,
-            ScheduleLifecycle scheduleService) {
+            ScheduleLifecycle scheduleService,
+            AuditLog auditLog) {
         this.helper = helper;
         this.scheduleQuery = scheduleQuery;
         this.vendorQuery = vendorQuery;
         this.scheduleService = scheduleService;
+        this.auditLog = auditLog;
     }
 
     @Operation(summary = "List schedules",
@@ -177,6 +182,10 @@ public class ScheduleController {
         ServiceSchedule sched =
                 scheduleService.completeSchedule(
                         scheduleId, orgId, completion);
+        auditLog.log(orgId, user.getUsername(),
+                "Schedule", scheduleId,
+                sched.getServiceType(),
+                AuditAction.COMPLETE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Schedule completed");
         if ("item".equals(redirectTo)) {
@@ -212,6 +221,10 @@ public class ScheduleController {
         ServiceSchedule sched =
                 scheduleService.skipSchedule(
                         scheduleId, orgId);
+        auditLog.log(orgId, user.getUsername(),
+                "Schedule", scheduleId,
+                sched.getServiceType(),
+                AuditAction.SKIP, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Schedule skipped");
         return "redirect:/items/"
@@ -240,6 +253,9 @@ public class ScheduleController {
         UUID orgId = user.getOrganization().getId();
         scheduleService.deactivateSchedule(
                 scheduleId, orgId);
+        auditLog.log(orgId, user.getUsername(),
+                "Schedule", scheduleId, "Schedule",
+                AuditAction.DELETE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Schedule deleted");
         return "redirect:/schedules";
@@ -303,6 +319,9 @@ public class ScheduleController {
         scheduleService.editSchedule(scheduleId, orgId,
                 serviceType, due, frequencyInterval,
                 frequencyUnit, vendor);
+        auditLog.log(orgId, user.getUsername(),
+                "Schedule", scheduleId, serviceType,
+                AuditAction.UPDATE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Schedule updated");
         return "redirect:/schedules";

--- a/src/main/java/solutions/mystuff/application/web/VendorController.java
+++ b/src/main/java/solutions/mystuff/application/web/VendorController.java
@@ -7,8 +7,11 @@ import java.util.List;
 import java.util.UUID;
 
 import solutions.mystuff.domain.model.AppUser;
+import solutions.mystuff.domain.model.AuditAction;
 import solutions.mystuff.domain.model.ParsedAltPhone;
+import solutions.mystuff.domain.model.Vendor;
 import solutions.mystuff.domain.model.VendorData;
+import solutions.mystuff.domain.port.in.AuditLog;
 import solutions.mystuff.domain.port.in.VendorImportExport;
 import solutions.mystuff.domain.port.in.VendorManagement;
 import solutions.mystuff.domain.port.in.VendorQuery;
@@ -54,16 +57,19 @@ public class VendorController {
     private final VendorManagement vendorService;
     private final VendorQuery vendorQuery;
     private final VendorImportExport importExport;
+    private final AuditLog auditLog;
 
     public VendorController(
             ControllerHelper helper,
             VendorManagement vendorService,
             VendorQuery vendorQuery,
-            VendorImportExport importExport) {
+            VendorImportExport importExport,
+            AuditLog auditLog) {
         this.helper = helper;
         this.vendorService = vendorService;
         this.vendorQuery = vendorQuery;
         this.importExport = importExport;
+        this.auditLog = auditLog;
     }
 
     @Operation(summary = "List vendors",
@@ -176,7 +182,12 @@ public class VendorController {
                 postalCode, country, website, notes,
                 buildAltPhones(altPhoneNumber,
                         altPhoneLabel));
-        vendorService.createVendor(orgId, data);
+        Vendor created =
+                vendorService.createVendor(orgId, data);
+        auditLog.log(orgId, user.getUsername(),
+                "Vendor", created.getId(),
+                created.getName(),
+                AuditAction.CREATE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Vendor created");
         return "redirect:/vendors";
@@ -263,8 +274,12 @@ public class VendorController {
                 postalCode, country, website, notes,
                 buildAltPhones(altPhoneNumber,
                         altPhoneLabel));
-        vendorService.updateVendor(
+        Vendor updated = vendorService.updateVendor(
                 orgId, vendorId, data);
+        auditLog.log(orgId, user.getUsername(),
+                "Vendor", updated.getId(),
+                updated.getName(),
+                AuditAction.UPDATE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Vendor updated");
         return "redirect:/vendors";
@@ -290,9 +305,14 @@ public class VendorController {
             RedirectAttributes redirectAttrs) {
         AppUser user = helper.resolveUser(principal);
         helper.setOrgMdc(user);
-        vendorService.deleteVendor(
-                user.getOrganization().getId(),
-                vendorId);
+        UUID orgId = user.getOrganization().getId();
+        String vendorName = vendorQuery
+                .findVendor(vendorId, orgId)
+                .map(Vendor::getName).orElse("Unknown");
+        vendorService.deleteVendor(orgId, vendorId);
+        auditLog.log(orgId, user.getUsername(),
+                "Vendor", vendorId, vendorName,
+                AuditAction.DELETE, null);
         redirectAttrs.addFlashAttribute(
                 "success", "Vendor deleted");
         return "redirect:/vendors";

--- a/src/main/java/solutions/mystuff/domain/model/AuditAction.java
+++ b/src/main/java/solutions/mystuff/domain/model/AuditAction.java
@@ -1,0 +1,37 @@
+package solutions.mystuff.domain.model;
+
+/**
+ * Enumeration of actions that can be recorded in the audit trail.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class AuditAction {
+ *         &lt;&lt;enumeration&gt;&gt;
+ *         CREATE
+ *         UPDATE
+ *         DELETE
+ *         COMPLETE
+ *         SKIP
+ *     }
+ *     AuditEntry --> AuditAction
+ * </div>
+ *
+ * @see AuditEntry
+ */
+public enum AuditAction {
+
+    /** A new entity was created. */
+    CREATE,
+
+    /** An existing entity was modified. */
+    UPDATE,
+
+    /** An entity was deleted. */
+    DELETE,
+
+    /** A schedule was completed. */
+    COMPLETE,
+
+    /** A schedule occurrence was skipped. */
+    SKIP
+}

--- a/src/main/java/solutions/mystuff/domain/model/AuditEntry.java
+++ b/src/main/java/solutions/mystuff/domain/model/AuditEntry.java
@@ -1,0 +1,155 @@
+package solutions.mystuff.domain.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+/**
+ * Immutable record of a user action for the audit trail.
+ *
+ * <p>Each entry captures who did what, to which entity, and when.
+ * Entries are never updated or deleted, only created.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class AuditEntry {
+ *         UUID id
+ *         UUID organizationId
+ *         String username
+ *         String entityType
+ *         UUID entityId
+ *         String entityName
+ *         AuditAction action
+ *         String details
+ *         Instant timestamp
+ *     }
+ *     AuditEntry --> AuditAction
+ * </div>
+ *
+ * @see AuditAction
+ */
+@Entity
+@Table(name = "audit_entries")
+public class AuditEntry {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "organization_id", nullable = false)
+    private UUID organizationId;
+
+    @Column(nullable = false, length = 200)
+    private String username;
+
+    @Column(name = "entity_type", nullable = false,
+            length = 50)
+    private String entityType;
+
+    @Column(name = "entity_id", nullable = false)
+    private UUID entityId;
+
+    @Column(name = "entity_name", nullable = false,
+            length = 250)
+    private String entityName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AuditAction action;
+
+    @Column(columnDefinition = "TEXT")
+    private String details;
+
+    @Column(nullable = false)
+    private Instant timestamp;
+
+    /** Assigns a UUIDv7 and timestamp on persist. */
+    @PrePersist
+    protected void onCreate() {
+        if (id == null) {
+            id = UuidV7.generate();
+        }
+        if (timestamp == null) {
+            timestamp = Instant.now();
+        }
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getOrganizationId() {
+        return organizationId;
+    }
+
+    public void setOrganizationId(UUID organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEntityType() {
+        return entityType;
+    }
+
+    public void setEntityType(String entityType) {
+        this.entityType = entityType;
+    }
+
+    public UUID getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(UUID entityId) {
+        this.entityId = entityId;
+    }
+
+    public String getEntityName() {
+        return entityName;
+    }
+
+    public void setEntityName(String entityName) {
+        this.entityName = entityName;
+    }
+
+    public AuditAction getAction() {
+        return action;
+    }
+
+    public void setAction(AuditAction action) {
+        this.action = action;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    public void setDetails(String details) {
+        this.details = details;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/solutions/mystuff/domain/port/in/AuditLog.java
+++ b/src/main/java/solutions/mystuff/domain/port/in/AuditLog.java
@@ -1,0 +1,49 @@
+package solutions.mystuff.domain.port.in;
+
+import java.util.List;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.AuditAction;
+import solutions.mystuff.domain.model.AuditEntry;
+
+/**
+ * Inbound port for recording and querying audit trail entries.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class AuditLog {
+ *         +log(UUID, String, String, UUID, String, AuditAction, String) void
+ *         +findRecentByOrganization(UUID, int) List~AuditEntry~
+ *         +findByEntityId(UUID) List~AuditEntry~
+ *     }
+ *     AuditLogService ..|> AuditLog
+ * </div>
+ *
+ * @see solutions.mystuff.domain.model.AuditEntry
+ * @see solutions.mystuff.domain.model.AuditAction
+ */
+public interface AuditLog {
+
+    /**
+     * Records an audit entry.
+     *
+     * @param orgId      the organization ID
+     * @param username   the acting user
+     * @param entityType entity type (Item, Schedule, etc.)
+     * @param entityId   the entity's ID
+     * @param entityName human-readable entity name
+     * @param action     the action performed
+     * @param details    optional details (nullable)
+     */
+    void log(UUID orgId, String username,
+             String entityType, UUID entityId,
+             String entityName, AuditAction action,
+             String details);
+
+    /** Find the most recent audit entries for an organization. */
+    List<AuditEntry> findRecentByOrganization(
+            UUID orgId, int limit);
+
+    /** Find all audit entries for a specific entity. */
+    List<AuditEntry> findByEntityId(UUID entityId);
+}

--- a/src/main/java/solutions/mystuff/domain/port/out/AuditEntryRepository.java
+++ b/src/main/java/solutions/mystuff/domain/port/out/AuditEntryRepository.java
@@ -1,0 +1,34 @@
+package solutions.mystuff.domain.port.out;
+
+import java.util.List;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.AuditEntry;
+
+/**
+ * Outbound port for persisting and retrieving audit entries.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class AuditEntryRepository {
+ *         +save(AuditEntry) AuditEntry
+ *         +findRecentByOrganizationId(UUID, int) List~AuditEntry~
+ *         +findByEntityId(UUID) List~AuditEntry~
+ *     }
+ *     JpaAuditEntryRepository ..|> AuditEntryRepository
+ * </div>
+ *
+ * @see solutions.mystuff.domain.model.AuditEntry
+ */
+public interface AuditEntryRepository {
+
+    /** Persist a new audit entry. */
+    AuditEntry save(AuditEntry entry);
+
+    /** Find the most recent audit entries for an organization. */
+    List<AuditEntry> findRecentByOrganizationId(
+            UUID organizationId, int limit);
+
+    /** Find all audit entries for a specific entity. */
+    List<AuditEntry> findByEntityId(UUID entityId);
+}

--- a/src/main/java/solutions/mystuff/domain/service/AuditLogService.java
+++ b/src/main/java/solutions/mystuff/domain/service/AuditLogService.java
@@ -1,0 +1,84 @@
+package solutions.mystuff.domain.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.AuditAction;
+import solutions.mystuff.domain.model.AuditEntry;
+import solutions.mystuff.domain.port.in.AuditLog;
+import solutions.mystuff.domain.port.out.AuditEntryRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation
+        .Transactional;
+
+/**
+ * Records and queries audit trail entries.
+ *
+ * <div class="mermaid">
+ * sequenceDiagram
+ *     participant S as DomainService
+ *     participant A as AuditLogService
+ *     participant R as AuditEntryRepository
+ *     S-&gt;&gt;A: log(orgId, user, type, id, name, action, details)
+ *     A-&gt;&gt;R: save(entry)
+ * </div>
+ *
+ * @see AuditLog
+ * @see AuditEntryRepository
+ */
+@Service
+public class AuditLogService implements AuditLog {
+
+    private static final Logger log =
+            LoggerFactory.getLogger(
+                    AuditLogService.class);
+
+    private final AuditEntryRepository auditRepo;
+
+    /** Creates the service with its repository dependency. */
+    public AuditLogService(
+            AuditEntryRepository auditRepo) {
+        this.auditRepo = auditRepo;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Transactional
+    public void log(UUID orgId, String username,
+                    String entityType, UUID entityId,
+                    String entityName,
+                    AuditAction action,
+                    String details) {
+        AuditEntry entry = new AuditEntry();
+        entry.setOrganizationId(orgId);
+        entry.setUsername(username);
+        entry.setEntityType(entityType);
+        entry.setEntityId(entityId);
+        entry.setEntityName(entityName);
+        entry.setAction(action);
+        entry.setDetails(details);
+        auditRepo.save(entry);
+        log.debug("Audit: {} {} {} '{}'",
+                username, action, entityType,
+                entityName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Transactional(readOnly = true)
+    public List<AuditEntry> findRecentByOrganization(
+            UUID orgId, int limit) {
+        return auditRepo.findRecentByOrganizationId(
+                orgId, limit);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Transactional(readOnly = true)
+    public List<AuditEntry> findByEntityId(
+            UUID entityId) {
+        return auditRepo.findByEntityId(entityId);
+    }
+}

--- a/src/main/java/solutions/mystuff/infrastructure/persistence/JpaAuditEntryRepository.java
+++ b/src/main/java/solutions/mystuff/infrastructure/persistence/JpaAuditEntryRepository.java
@@ -1,0 +1,58 @@
+package solutions.mystuff.infrastructure.persistence;
+
+import java.util.List;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.AuditEntry;
+import solutions.mystuff.domain.port.out
+        .AuditEntryRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository
+        .JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Spring Data JPA adapter for {@link AuditEntryRepository}.
+ *
+ * <div class="mermaid">
+ * classDiagram
+ *     class JpaAuditEntryRepository
+ *     class JpaRepository~AuditEntry, UUID~
+ *     class AuditEntryRepository
+ *     JpaAuditEntryRepository --|&gt; JpaRepository
+ *     JpaAuditEntryRepository --|&gt; AuditEntryRepository
+ * </div>
+ *
+ * @see AuditEntryRepository
+ * @see AuditEntry
+ */
+@Repository
+public interface JpaAuditEntryRepository
+        extends JpaRepository<AuditEntry, UUID>,
+        AuditEntryRepository {
+
+    /** Paginated helper for recent entries. */
+    @Query("SELECT e FROM AuditEntry e "
+            + "WHERE e.organizationId = :orgId "
+            + "ORDER BY e.timestamp DESC")
+    List<AuditEntry> findRecentByOrgId(
+            @Param("orgId") UUID organizationId,
+            org.springframework.data.domain
+                    .Pageable pageable);
+
+    @Override
+    default List<AuditEntry> findRecentByOrganizationId(
+            UUID organizationId, int limit) {
+        return findRecentByOrgId(organizationId,
+                PageRequest.of(0, limit));
+    }
+
+    @Override
+    @Query("SELECT e FROM AuditEntry e "
+            + "WHERE e.entityId = :entityId "
+            + "ORDER BY e.timestamp DESC")
+    List<AuditEntry> findByEntityId(
+            @Param("entityId") UUID entityId);
+}

--- a/src/main/resources/db/migration/V15__add_audit_entries.sql
+++ b/src/main/resources/db/migration/V15__add_audit_entries.sql
@@ -1,0 +1,17 @@
+CREATE TABLE audit_entries (
+    id              UUID        NOT NULL PRIMARY KEY,
+    organization_id UUID        NOT NULL REFERENCES organizations(id),
+    username        VARCHAR(200) NOT NULL,
+    entity_type     VARCHAR(50)  NOT NULL,
+    entity_id       UUID        NOT NULL,
+    entity_name     VARCHAR(250) NOT NULL,
+    action          VARCHAR(20)  NOT NULL,
+    details         TEXT,
+    timestamp       TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_audit_entries_org_ts
+    ON audit_entries (organization_id, timestamp DESC);
+
+CREATE INDEX idx_audit_entries_entity
+    ON audit_entries (entity_id);

--- a/src/main/resources/templates/activity.html
+++ b/src/main/resources/templates/activity.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head th:replace="~{layout :: head}"></head>
+<body>
+<header th:replace="~{layout :: header}"></header>
+<div th:replace="~{layout :: toasts}"></div>
+<main id="main-content">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li><a th:href="@{/}">Home</a></li>
+            <li>Activity</li>
+        </ol>
+    </nav>
+
+    <div th:if="${noOrganization}">
+        <p>You are not assigned to an organization.
+           Please contact an administrator.</p>
+    </div>
+    <div th:unless="${noOrganization}">
+        <h1>Activity Log</h1>
+
+        <p th:if="${auditEntries == null or #lists.isEmpty(auditEntries)}">No activity recorded yet.</p>
+        <div class="table-scroll-wrapper">
+        <table th:if="${auditEntries != null and !#lists.isEmpty(auditEntries)}">
+            <thead>
+            <tr>
+                <th>Time</th>
+                <th>User</th>
+                <th>Action</th>
+                <th>Type</th>
+                <th>Name</th>
+                <th>Details</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="e : ${auditEntries}">
+                <td th:text="${#temporals.format(e.timestamp, 'yyyy-MM-dd HH:mm')}" class="nowrap"></td>
+                <td th:text="${e.username}"></td>
+                <td th:text="${e.action}"></td>
+                <td th:text="${e.entityType}"></td>
+                <td th:text="${e.entityName}"></td>
+                <td th:text="${e.details}"></td>
+            </tr>
+            </tbody>
+        </table>
+        </div>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -35,6 +35,7 @@
         <div class="dashboard-links">
             <a th:href="@{/schedules}" class="btn">View All Schedules</a>
             <a th:href="@{/items}" class="btn">View All Items</a>
+            <a th:href="@{/activity}" class="btn">View Activity Log</a>
         </div>
 
         <div class="quick-action-cards">
@@ -57,7 +58,7 @@
         </div>
 
         <section class="recent-activity">
-            <h2>Recent Activity</h2>
+            <h2>Recent Service Records</h2>
             <p th:if="${#lists.isEmpty(recentRecords)}">No service records yet.</p>
             <div class="table-scroll-wrapper">
             <table th:unless="${#lists.isEmpty(recentRecords)}">
@@ -75,6 +76,33 @@
                     <td th:text="${r.item.name}"></td>
                     <td th:text="${r.serviceType}"></td>
                     <td th:text="${r.summary}"></td>
+                </tr>
+                </tbody>
+            </table>
+            </div>
+        </section>
+
+        <section class="audit-feed">
+            <h2>Activity Feed</h2>
+            <p th:if="${auditEntries == null or #lists.isEmpty(auditEntries)}">No activity yet.</p>
+            <div class="table-scroll-wrapper">
+            <table th:if="${auditEntries != null and !#lists.isEmpty(auditEntries)}">
+                <thead>
+                <tr>
+                    <th>Time</th>
+                    <th>User</th>
+                    <th>Action</th>
+                    <th>Type</th>
+                    <th>Name</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="e : ${auditEntries}">
+                    <td th:text="${#temporals.format(e.timestamp, 'yyyy-MM-dd HH:mm')}" class="nowrap"></td>
+                    <td th:text="${e.username}"></td>
+                    <td th:text="${e.action}"></td>
+                    <td th:text="${e.entityType}"></td>
+                    <td th:text="${e.entityName}"></td>
                 </tr>
                 </tbody>
             </table>

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -475,6 +475,25 @@
                             </div>
                             <p th:if="${itemSchedules == null or #lists.isEmpty(itemSchedules)}"
                                class="detail-empty">No schedules.</p>
+                            <div class="detail-section"
+                                 th:if="${itemAuditEntries != null and !#lists.isEmpty(itemAuditEntries)}">
+                                <h4>Audit History</h4>
+                                <table class="detail-table">
+                                    <thead><tr>
+                                        <th>Time</th><th>User</th>
+                                        <th>Action</th><th>Details</th>
+                                    </tr></thead>
+                                    <tbody>
+                                    <tr th:each="ae : ${itemAuditEntries}">
+                                        <td th:text="${#temporals.format(ae.timestamp, 'yyyy-MM-dd HH:mm')}"
+                                            style="white-space:nowrap"></td>
+                                        <td th:text="${ae.username}"></td>
+                                        <td th:text="${ae.action}"></td>
+                                        <td th:text="${ae.details}"></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     </td>
                 </tr>

--- a/src/test/java/solutions/mystuff/application/web/ActivityControllerIntegrationTest.java
+++ b/src/test/java/solutions/mystuff/application/web/ActivityControllerIntegrationTest.java
@@ -20,39 +20,32 @@ import static org.springframework.test.web.servlet
         .result.MockMvcResultMatchers.view;
 
 /**
- * Integration tests for {@link DashboardController}.
+ * Integration tests for {@link ActivityController}.
  *
  * <div class="mermaid">
  * sequenceDiagram
- *     Test->>MockMvc: GET /
- *     MockMvc->>DashboardController: dashboard(...)
- *     DashboardController-->>MockMvc: dashboard view
+ *     Test-&gt;&gt;MockMvc: GET /activity
+ *     MockMvc-&gt;&gt;ActivityController: activity(...)
+ *     ActivityController--&gt;&gt;MockMvc: activity view
  * </div>
  */
 @SpringBootTest
 @AutoConfigureMockMvc
-@DisplayName("Dashboard Controller Integration")
-class DashboardControllerIntegrationTest {
+@DisplayName("Activity Controller Integration")
+class ActivityControllerIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
 
     @Test
-    @DisplayName("should render dashboard for user with org")
-    void shouldRenderDashboardWhenUserHasOrg()
+    @DisplayName("should render activity page for user"
+            + " with org")
+    void shouldRenderActivityWhenUserHasOrg()
             throws Exception {
-        mockMvc.perform(get("/")
+        mockMvc.perform(get("/activity")
                         .with(user("dev").roles("USER")))
                 .andExpect(status().isOk())
-                .andExpect(view().name("dashboard"))
-                .andExpect(model().attributeExists(
-                        "overdueCount"))
-                .andExpect(model().attributeExists(
-                        "dueSoonCount"))
-                .andExpect(model().attributeExists(
-                        "totalItems"))
-                .andExpect(model().attributeExists(
-                        "recentRecords"))
+                .andExpect(view().name("activity"))
                 .andExpect(model().attributeExists(
                         "auditEntries"))
                 .andExpect(model().attributeExists(
@@ -65,13 +58,12 @@ class DashboardControllerIntegrationTest {
     @DisplayName("should show no-org for unknown user")
     void shouldShowNoOrgWhenUserLacksOrganization()
             throws Exception {
-        mockMvc.perform(get("/")
+        mockMvc.perform(get("/activity")
                         .with(user("unknown")
                                 .roles("USER")))
                 .andExpect(status().isOk())
-                .andExpect(view().name("dashboard"))
+                .andExpect(view().name("activity"))
                 .andExpect(model().attribute(
                         "noOrganization", true));
     }
-
 }

--- a/src/test/java/solutions/mystuff/domain/model/AuditActionTest.java
+++ b/src/test/java/solutions/mystuff/domain/model/AuditActionTest.java
@@ -1,0 +1,31 @@
+package solutions.mystuff.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("AuditAction")
+class AuditActionTest {
+
+    @Test
+    @DisplayName("should have five values")
+    void shouldHaveFiveValues() {
+        assertEquals(5, AuditAction.values().length);
+    }
+
+    @Test
+    @DisplayName("should parse from string")
+    void shouldParseFromString() {
+        assertEquals(AuditAction.CREATE,
+                AuditAction.valueOf("CREATE"));
+        assertEquals(AuditAction.UPDATE,
+                AuditAction.valueOf("UPDATE"));
+        assertEquals(AuditAction.DELETE,
+                AuditAction.valueOf("DELETE"));
+        assertEquals(AuditAction.COMPLETE,
+                AuditAction.valueOf("COMPLETE"));
+        assertEquals(AuditAction.SKIP,
+                AuditAction.valueOf("SKIP"));
+    }
+}

--- a/src/test/java/solutions/mystuff/domain/model/AuditEntryTest.java
+++ b/src/test/java/solutions/mystuff/domain/model/AuditEntryTest.java
@@ -1,0 +1,75 @@
+package solutions.mystuff.domain.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("AuditEntry")
+class AuditEntryTest {
+
+    @Test
+    @DisplayName("should assign id and timestamp on"
+            + " create")
+    void shouldAssignIdAndTimestampWhenCreated() {
+        AuditEntry entry = new AuditEntry();
+        entry.onCreate();
+        assertThat(entry.getId()).isNotNull();
+        assertThat(entry.getTimestamp()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("should not overwrite existing id")
+    void shouldNotOverwriteExistingId() {
+        UUID fixed = UuidV7.generate();
+        AuditEntry entry = new AuditEntry();
+        entry.setId(fixed);
+        entry.onCreate();
+        assertThat(entry.getId()).isEqualTo(fixed);
+    }
+
+    @Test
+    @DisplayName("should not overwrite existing"
+            + " timestamp")
+    void shouldNotOverwriteExistingTimestamp() {
+        Instant fixed = Instant.parse(
+                "2026-01-01T00:00:00Z");
+        AuditEntry entry = new AuditEntry();
+        entry.setTimestamp(fixed);
+        entry.onCreate();
+        assertThat(entry.getTimestamp())
+                .isEqualTo(fixed);
+    }
+
+    @Test
+    @DisplayName("should store all fields")
+    void shouldStoreAllFields() {
+        UUID orgId = UuidV7.generate();
+        UUID entityId = UuidV7.generate();
+        AuditEntry entry = new AuditEntry();
+        entry.setOrganizationId(orgId);
+        entry.setUsername("dev");
+        entry.setEntityType("Item");
+        entry.setEntityId(entityId);
+        entry.setEntityName("Furnace");
+        entry.setAction(AuditAction.CREATE);
+        entry.setDetails("Created item");
+        assertThat(entry.getOrganizationId())
+                .isEqualTo(orgId);
+        assertThat(entry.getUsername())
+                .isEqualTo("dev");
+        assertThat(entry.getEntityType())
+                .isEqualTo("Item");
+        assertThat(entry.getEntityId())
+                .isEqualTo(entityId);
+        assertThat(entry.getEntityName())
+                .isEqualTo("Furnace");
+        assertThat(entry.getAction())
+                .isEqualTo(AuditAction.CREATE);
+        assertThat(entry.getDetails())
+                .isEqualTo("Created item");
+    }
+}

--- a/src/test/java/solutions/mystuff/domain/service/AuditLogServiceTest.java
+++ b/src/test/java/solutions/mystuff/domain/service/AuditLogServiceTest.java
@@ -1,0 +1,113 @@
+package solutions.mystuff.domain.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import solutions.mystuff.domain.model.AuditAction;
+import solutions.mystuff.domain.model.AuditEntry;
+import solutions.mystuff.domain.model.UuidV7;
+import solutions.mystuff.domain.port.out.AuditEntryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("AuditLogService")
+class AuditLogServiceTest {
+
+    private final AuditEntryRepository repo =
+            mock(AuditEntryRepository.class);
+    private final AuditLogService service =
+            new AuditLogService(repo);
+
+    private final UUID orgId = UuidV7.generate();
+
+    @Test
+    @DisplayName("should save audit entry when logging")
+    void shouldSaveEntryWhenLogging() {
+        when(repo.save(any(AuditEntry.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        service.log(orgId, "dev", "Item",
+                UuidV7.generate(), "Furnace",
+                AuditAction.CREATE, null);
+        verify(repo).save(any(AuditEntry.class));
+    }
+
+    @Test
+    @DisplayName("should populate all fields on entry")
+    void shouldPopulateAllFieldsWhenLogging() {
+        UUID entityId = UuidV7.generate();
+        when(repo.save(any(AuditEntry.class)))
+                .thenAnswer(i -> {
+                    AuditEntry e = i.getArgument(0);
+                    assertThat(e.getOrganizationId())
+                            .isEqualTo(orgId);
+                    assertThat(e.getUsername())
+                            .isEqualTo("dev");
+                    assertThat(e.getEntityType())
+                            .isEqualTo("Item");
+                    assertThat(e.getEntityId())
+                            .isEqualTo(entityId);
+                    assertThat(e.getEntityName())
+                            .isEqualTo("Furnace");
+                    assertThat(e.getAction())
+                            .isEqualTo(AuditAction.CREATE);
+                    assertThat(e.getDetails()).isNull();
+                    return e;
+                });
+        service.log(orgId, "dev", "Item",
+                entityId, "Furnace",
+                AuditAction.CREATE, null);
+    }
+
+    @Test
+    @DisplayName("should include details when provided")
+    void shouldIncludeDetailsWhenProvided() {
+        when(repo.save(any(AuditEntry.class)))
+                .thenAnswer(i -> {
+                    AuditEntry e = i.getArgument(0);
+                    assertThat(e.getDetails())
+                            .isEqualTo("updated name");
+                    return e;
+                });
+        service.log(orgId, "dev", "Item",
+                UuidV7.generate(), "Furnace",
+                AuditAction.UPDATE, "updated name");
+    }
+
+    @Test
+    @DisplayName("should delegate to repository for"
+            + " recent entries")
+    void shouldDelegateRecentQuery() {
+        UUID eid = UuidV7.generate();
+        AuditEntry entry = new AuditEntry();
+        entry.setEntityId(eid);
+        when(repo.findRecentByOrganizationId(orgId, 10))
+                .thenReturn(List.of(entry));
+        List<AuditEntry> result =
+                service.findRecentByOrganization(
+                        orgId, 10);
+        assertThat(result).hasSize(1);
+        verify(repo).findRecentByOrganizationId(
+                orgId, 10);
+    }
+
+    @Test
+    @DisplayName("should delegate to repository for"
+            + " entity entries")
+    void shouldDelegateEntityQuery() {
+        UUID entityId = UuidV7.generate();
+        AuditEntry entry = new AuditEntry();
+        entry.setEntityId(entityId);
+        when(repo.findByEntityId(entityId))
+                .thenReturn(List.of(entry));
+        List<AuditEntry> result =
+                service.findByEntityId(entityId);
+        assertThat(result).hasSize(1);
+        verify(repo).findByEntityId(entityId);
+    }
+}


### PR DESCRIPTION
## Summary
- `AuditAction` enum: CREATE, UPDATE, DELETE, COMPLETE, SKIP
- `AuditEntry` entity with organizationId, username, entityType, entityId, entityName, action, details, timestamp
- `AuditLog` inbound port + `AuditLogService` for logging and querying
- Flyway V15: audit_entries table with indexes on (org_id, timestamp) and (entity_id)
- Audit logging added to all controllers: item CRUD, record CRUD, schedule lifecycle, vendor CRUD
- Dashboard activity feed showing recent entries
- Per-item audit history in item detail view
- Full activity log page at `/activity`
- 9 tests (5 unit, 2 integration, 2 model)

Closes #82

## Test plan
- [ ] CI passes
- [ ] Create an item — audit entry logged, visible on dashboard activity feed
- [ ] Delete a vendor — audit entry logged
- [ ] Complete a schedule — audit entry with COMPLETE action
- [ ] View item detail — audit history section shows item-specific entries
- [ ] Visit /activity — full audit log with all entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)